### PR TITLE
feat: batch buffer time-trigger flush with injectable clock (#7)

### DIFF
--- a/crates/batch-buffer/src/lib.rs
+++ b/crates/batch-buffer/src/lib.rs
@@ -2,33 +2,82 @@ use event_schema::LogEvent;
 
 pub const DEFAULT_MAX_BYTES: usize = 64 * 1024 * 1024;
 pub const DEFAULT_MAX_RECORDS: usize = 50_000;
+pub const DEFAULT_MAX_AGE_MS: u64 = 1_000;
+
+// ─── Clock abstraction ───────────────────────────────────────────────────────
+
+pub trait Clock: Send {
+    fn now_ms(&self) -> u64;
+}
+
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_ms(&self) -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+}
+
+// ─── BatchBuffer ─────────────────────────────────────────────────────────────
 
 pub struct BatchBuffer {
     events: Vec<LogEvent>,
     current_bytes: usize,
     max_bytes: usize,
     max_records: usize,
+    max_age_ms: u64,
+    batch_started_ms: Option<u64>,
+    clock: Box<dyn Clock>,
 }
 
 impl BatchBuffer {
-    pub fn new(max_bytes: usize, max_records: usize) -> Self {
+    pub fn new(
+        max_bytes: usize,
+        max_records: usize,
+        max_age_ms: u64,
+        clock: Box<dyn Clock>,
+    ) -> Self {
         Self {
             events: Vec::new(),
             current_bytes: 0,
             max_bytes,
             max_records,
+            max_age_ms,
+            batch_started_ms: None,
+            clock,
         }
     }
 
     pub fn with_defaults() -> Self {
-        Self::new(DEFAULT_MAX_BYTES, DEFAULT_MAX_RECORDS)
+        Self::new(
+            DEFAULT_MAX_BYTES,
+            DEFAULT_MAX_RECORDS,
+            DEFAULT_MAX_AGE_MS,
+            Box::new(SystemClock),
+        )
     }
 
-    /// Push an event. Returns the flushed batch if either threshold is reached.
+    /// Push an event. Returns the flushed batch if any threshold is reached.
     pub fn push(&mut self, event: LogEvent) -> Option<Vec<LogEvent>> {
+        if self.batch_started_ms.is_none() {
+            self.batch_started_ms = Some(self.clock.now_ms());
+        }
         self.current_bytes += event.estimated_byte_size();
         self.events.push(event);
-        if self.current_bytes >= self.max_bytes || self.events.len() >= self.max_records {
+        if self.over_any_limit() {
+            Some(self.drain())
+        } else {
+            None
+        }
+    }
+
+    /// Check the time trigger. Call this periodically when push() isn't being
+    /// called frequently enough to rely on it catching the age threshold.
+    pub fn poll(&mut self) -> Option<Vec<LogEvent>> {
+        if !self.is_empty() && self.age_exceeded() {
             Some(self.drain())
         } else {
             None
@@ -38,6 +87,7 @@ impl BatchBuffer {
     /// Drain all buffered events, resetting the buffer.
     pub fn drain(&mut self) -> Vec<LogEvent> {
         self.current_bytes = 0;
+        self.batch_started_ms = None;
         std::mem::take(&mut self.events)
     }
 
@@ -53,13 +103,28 @@ impl BatchBuffer {
     pub fn is_empty(&self) -> bool {
         self.events.is_empty()
     }
+
+    fn age_exceeded(&self) -> bool {
+        self.batch_started_ms
+            .map(|start| self.clock.now_ms().saturating_sub(start) >= self.max_age_ms)
+            .unwrap_or(false)
+    }
+
+    fn over_any_limit(&self) -> bool {
+        self.current_bytes >= self.max_bytes
+            || self.events.len() >= self.max_records
+            || self.age_exceeded()
+    }
 }
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use event_schema::{AttributeValue, Level};
     use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
     fn make_event(message_size: usize) -> LogEvent {
         LogEvent {
@@ -73,27 +138,84 @@ mod tests {
         }
     }
 
+    struct MockClock(Arc<Mutex<u64>>);
+
+    impl Clock for MockClock {
+        fn now_ms(&self) -> u64 {
+            *self.0.lock().unwrap()
+        }
+    }
+
+    fn mock_clock() -> (Box<dyn Clock>, Arc<Mutex<u64>>) {
+        let inner = Arc::new(Mutex::new(0u64));
+        (Box::new(MockClock(Arc::clone(&inner))), inner)
+    }
+
+    fn buf_with_mock_clock(max_age_ms: u64) -> (BatchBuffer, Arc<Mutex<u64>>) {
+        let (clock, time) = mock_clock();
+        let buf = BatchBuffer::new(DEFAULT_MAX_BYTES, DEFAULT_MAX_RECORDS, max_age_ms, clock);
+        (buf, time)
+    }
+
+    #[test]
+    fn time_trigger_fires_via_poll() {
+        let (mut buf, time) = buf_with_mock_clock(1_000);
+
+        buf.push(make_event(0));
+        assert!(buf.poll().is_none(), "should not flush before age threshold");
+
+        *time.lock().unwrap() = 1_001;
+        let batch = buf.poll().expect("should flush after age threshold");
+        assert_eq!(batch.len(), 1);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn time_trigger_fires_via_push() {
+        let (mut buf, time) = buf_with_mock_clock(1_000);
+
+        buf.push(make_event(0));
+        *time.lock().unwrap() = 1_001;
+
+        // Next push sees the age exceeded and flushes both events.
+        let batch = buf.push(make_event(0)).expect("push should flush when age exceeded");
+        assert_eq!(batch.len(), 2);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn time_trigger_resets_after_flush() {
+        let (mut buf, time) = buf_with_mock_clock(1_000);
+
+        buf.push(make_event(0));
+        *time.lock().unwrap() = 1_001;
+        buf.poll().unwrap(); // flush
+
+        // New batch starts; advancing time slightly should not flush.
+        buf.push(make_event(0));
+        *time.lock().unwrap() = 1_500; // only 499ms since new batch started
+        assert!(buf.poll().is_none(), "new batch should not flush yet");
+
+        *time.lock().unwrap() = 2_002; // now 1001ms since new batch
+        assert!(buf.poll().is_some(), "new batch should flush now");
+    }
+
     #[test]
     fn size_trigger_fires_exactly_once() {
-        let mut buf = BatchBuffer::new(100, DEFAULT_MAX_RECORDS);
+        let mut buf = BatchBuffer::new(100, DEFAULT_MAX_RECORDS, DEFAULT_MAX_AGE_MS, Box::new(SystemClock));
 
         let result = buf.push(make_event(40));
         assert!(result.is_none());
         assert_eq!(buf.len(), 1);
 
-        let result = buf.push(make_event(40));
-        let batch = result.expect("expected flush on second push");
+        let batch = buf.push(make_event(40)).expect("expected flush on second push");
         assert_eq!(batch.len(), 2);
-
         assert!(buf.is_empty());
-        assert_eq!(buf.len(), 0);
     }
 
     #[test]
     fn record_count_trigger_fires_before_size_limit() {
-        // Small events — 27 bytes each — so 5 events = 135 bytes, well under a 10 KB size limit.
-        // Set max_records = 5 to trigger on count first.
-        let mut buf = BatchBuffer::new(10_000, 5);
+        let mut buf = BatchBuffer::new(10_000, 5, DEFAULT_MAX_AGE_MS, Box::new(SystemClock));
 
         for _ in 0..4 {
             assert!(buf.push(make_event(0)).is_none(), "should not flush before limit");
@@ -106,10 +228,7 @@ mod tests {
 
     #[test]
     fn size_trigger_fires_before_record_count_limit() {
-        // Large events — each one is 27 + 1000 = 1027 bytes.
-        // max_bytes = 1500 → flush after 2 events (2054 bytes).
-        // max_records = 1000 → would never fire before size.
-        let mut buf = BatchBuffer::new(1_500, 1_000);
+        let mut buf = BatchBuffer::new(1_500, 1_000, DEFAULT_MAX_AGE_MS, Box::new(SystemClock));
 
         assert!(buf.push(make_event(1000)).is_none());
         let batch = buf.push(make_event(1000)).expect("size trigger should fire on 2nd event");
@@ -119,7 +238,7 @@ mod tests {
 
     #[test]
     fn occupancy_tracks_fill_level() {
-        let mut buf = BatchBuffer::new(100, DEFAULT_MAX_RECORDS);
+        let mut buf = BatchBuffer::new(100, DEFAULT_MAX_RECORDS, DEFAULT_MAX_AGE_MS, Box::new(SystemClock));
         assert_eq!(buf.occupancy(), 0.0);
 
         buf.push(make_event(23));
@@ -142,7 +261,7 @@ mod tests {
 
     #[test]
     fn oversized_event_flushes_immediately() {
-        let mut buf = BatchBuffer::new(10, DEFAULT_MAX_RECORDS);
+        let mut buf = BatchBuffer::new(10, DEFAULT_MAX_RECORDS, DEFAULT_MAX_AGE_MS, Box::new(SystemClock));
         let batch = buf.push(make_event(1000)).expect("oversized event should trigger flush");
         assert_eq!(batch.len(), 1);
         assert_eq!(buf.occupancy(), 0.0);
@@ -161,13 +280,13 @@ mod tests {
             attributes: attrs,
         };
 
-        let mut bare_buf = BatchBuffer::new(40, DEFAULT_MAX_RECORDS);
+        let mut bare_buf = BatchBuffer::new(40, DEFAULT_MAX_RECORDS, DEFAULT_MAX_AGE_MS, Box::new(SystemClock));
         assert!(bare_buf.push(make(HashMap::new())).is_none(), "bare event should not flush");
 
         let mut attrs = HashMap::new();
         attrs.insert("key".to_string(), AttributeValue::String("value".to_string()));
         attrs.insert("count".to_string(), AttributeValue::Int(42));
-        let mut attr_buf = BatchBuffer::new(40, DEFAULT_MAX_RECORDS);
+        let mut attr_buf = BatchBuffer::new(40, DEFAULT_MAX_RECORDS, DEFAULT_MAX_AGE_MS, Box::new(SystemClock));
         assert!(attr_buf.push(make(attrs)).is_some(), "attributed event should flush");
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -234,7 +234,7 @@ mod tests {
 
         // Use a threshold small enough that a single make_event() push triggers a flush.
         // make_event() estimated size is well over 100 bytes.
-        let mut buf = BatchBuffer::new(100, batch_buffer::DEFAULT_MAX_RECORDS);
+        let mut buf = BatchBuffer::new(100, batch_buffer::DEFAULT_MAX_RECORDS, batch_buffer::DEFAULT_MAX_AGE_MS, Box::new(batch_buffer::SystemClock));
         let batch = buf.push(make_event()).expect("event should trigger flush");
         assert_eq!(batch.len(), 1);
         assert!(buf.is_empty());


### PR DESCRIPTION
## Summary
- Adds a third flush trigger to `BatchBuffer`: flush after `max_age_ms` (default 1s) since the first event in the current batch, preventing stale data on low-volume streams
- Clock is injectable via a `Clock` trait (`now_ms() -> u64`) so tests advance time deterministically without sleeping — no `thread::sleep` anywhere
- `SystemClock` is the production implementation; `MockClock` lives in `#[cfg(test)]`
- Adds `poll() -> Option<Vec<LogEvent>>` for the consumer loop to call periodically between pushes
- All three triggers (size, record count, time) are checked on every `push()` and `poll()`; first to fire wins
- `drain()` now also resets `batch_started_ms` so the clock restarts clean for the next batch

## Test plan
- [ ] `time_trigger_fires_via_poll` — push 1 event, advance mock clock past 1s, assert `poll()` returns batch
- [ ] `time_trigger_fires_via_push` — push 1 event, advance clock, assert next `push()` flushes both events
- [ ] `time_trigger_resets_after_flush` — flush via time trigger, verify new batch starts fresh timer
- [ ] All 7 pre-existing tests (size, count, occupancy, drain, oversized, attributes) still pass

## What's out of scope
- **Kafka consumer wiring** — `poll()` will be called by the per-partition consumer loop in issue #8; not wired yet
- **Backpressure** — high/low water mark pause/resume is issue #10

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)