### PR TITLE
feat: Kafka consumer wired into flush pipeline (#8)

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,6 +19,8 @@ anyhow = { workspace = true }
 event-schema = { path = "../crates/event-schema" }
 manifest = { path = "../crates/manifest" }
 storage = { path = "../crates/storage" }
+batch-buffer = { path = "../crates/batch-buffer" }
+rdkafka = { version = "0.36", features = ["cmake-build"] }
 
 datafusion = "44"
 parquet = "53.4"
@@ -28,7 +30,6 @@ chrono = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
-batch-buffer = { path = "../crates/batch-buffer" }
 tower = { version = "0.5", features = ["util"] }
 object_store = { version = "0.11", features = ["aws"] }
 url = "2"

--- a/server/src/consumer.rs
+++ b/server/src/consumer.rs
@@ -1,0 +1,113 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use batch_buffer::BatchBuffer;
+use event_schema::LogEvent;
+use manifest::Manifest;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use rdkafka::ClientConfig;
+use tokio::sync::{broadcast, Mutex};
+use tokio::time::interval;
+
+use crate::flush_events;
+
+pub struct ConsumerConfig {
+    pub bootstrap_servers: String,
+    pub group_id: String,
+    pub topic: String,
+}
+
+impl Default for ConsumerConfig {
+    fn default() -> Self {
+        Self {
+            bootstrap_servers: std::env::var("KAFKA_BROKERS")
+                .unwrap_or_else(|_| "localhost:9092".to_string()),
+            group_id: std::env::var("KAFKA_GROUP_ID")
+                .unwrap_or_else(|_| "log-ingest".to_string()),
+            topic: std::env::var("KAFKA_TOPIC")
+                .unwrap_or_else(|_| "logs".to_string()),
+        }
+    }
+}
+
+/// Run the Kafka consumer loop until a shutdown signal is received.
+///
+/// Events are deserialized from JSON, fed into a BatchBuffer, and flushed to
+/// Parquet when any trigger fires (size / record count / time). On shutdown the
+/// buffer is drained so in-flight events are not lost.
+///
+/// Note: auto.commit is enabled here for simplicity. Issue #9 changes this to
+/// manual offset commit strictly after a successful Parquet flush.
+pub async fn run_consumer(
+    config: ConsumerConfig,
+    data_dir: PathBuf,
+    manifest: Arc<Mutex<Manifest>>,
+    mut shutdown: broadcast::Receiver<()>,
+) -> Result<()> {
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", &config.bootstrap_servers)
+        .set("group.id", &config.group_id)
+        .set("auto.offset.reset", "earliest")
+        .set("enable.auto.commit", "true")
+        .create()?;
+
+    consumer.subscribe(&[&config.topic])?;
+    tracing::info!("consumer subscribed to topic '{}'", config.topic);
+
+    let mut buffer = BatchBuffer::with_defaults();
+    let mut tick = interval(Duration::from_millis(100));
+
+    loop {
+        tokio::select! {
+            msg = consumer.recv() => {
+                match msg {
+                    Err(e) => tracing::warn!("kafka error: {e}"),
+                    Ok(m) => {
+                        let Some(payload) = m.payload() else { continue };
+                        match serde_json::from_slice::<LogEvent>(payload) {
+                            Err(e) => tracing::warn!("failed to deserialize message: {e}"),
+                            Ok(mut event) => {
+                                // Override with actual Kafka metadata — the producer's
+                                // embedded values may not match the assigned offset.
+                                event.kafka_partition = m.partition();
+                                event.kafka_offset = m.offset();
+
+                                if let Some(batch) = buffer.push(event) {
+                                    do_flush(&batch, &data_dir, &manifest).await;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ = tick.tick() => {
+                if let Some(batch) = buffer.poll() {
+                    do_flush(&batch, &data_dir, &manifest).await;
+                }
+            }
+            _ = shutdown.recv() => {
+                tracing::info!(
+                    "consumer shutting down — draining {} buffered events",
+                    buffer.len()
+                );
+                if !buffer.is_empty() {
+                    do_flush(&buffer.drain(), &data_dir, &manifest).await;
+                }
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn do_flush(batch: &[LogEvent], data_dir: &PathBuf, manifest: &Arc<Mutex<Manifest>>) {
+    let mut guard = manifest.lock().await;
+    match flush_events(batch, data_dir, &mut guard) {
+        Ok(path) => tracing::info!("flushed {} events → {}", batch.len(), path.display()),
+        Err(e) => tracing::error!("flush failed: {e:#}"),
+    }
+}

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,7 +1,5 @@
-// Library entry point for the server crate. Exposes flush_events so it can be
-// used by examples (e.g. examples/prefill.rs) and integration tests without
-// going through the HTTP API.
-
+pub use consumer::{run_consumer, ConsumerConfig};
 pub use flush::flush_events;
 
+mod consumer;
 mod flush;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,16 +1,16 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use arrow::array::{Array, BooleanArray, Int32Array, Int64Array, StringArray, StringViewArray};
 use arrow::datatypes::DataType;
 use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Json, Router};
 use datafusion::prelude::*;
-use event_schema::LogEvent;
 use manifest::Manifest;
 use serde::Deserialize;
-use server::flush_events;
-use tokio::sync::Mutex;
+use server::{run_consumer, ConsumerConfig};
+use tokio::sync::{broadcast, Mutex};
 
 // ─── HTTP API ────────────────────────────────────────────────────────────────
 
@@ -140,21 +140,54 @@ async fn main() {
         )
         .init();
 
-    let db_path = std::env::var("MANIFEST_PATH").unwrap_or_else(|_| "manifest.db".to_string());
-    let manifest = Manifest::open(Path::new(&db_path)).expect("open manifest");
-    let state = AppState {
-        manifest: Arc::new(Mutex::new(manifest)),
-    };
+    let data_dir = PathBuf::from(
+        std::env::var("DATA_DIR").unwrap_or_else(|_| "data".to_string()),
+    );
+    std::fs::create_dir_all(&data_dir).expect("create data dir");
 
+    let db_path = std::env::var("MANIFEST_PATH").unwrap_or_else(|_| "manifest.db".to_string());
+    let manifest = Arc::new(Mutex::new(
+        Manifest::open(Path::new(&db_path)).expect("open manifest"),
+    ));
+
+    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
+
+    // Start Kafka consumer as a background task.
+    let consumer_manifest = Arc::clone(&manifest);
+    tokio::spawn(async move {
+        if let Err(e) = run_consumer(
+            ConsumerConfig::default(),
+            data_dir,
+            consumer_manifest,
+            shutdown_rx,
+        )
+        .await
+        {
+            tracing::error!("consumer exited with error: {e:#}");
+        }
+    });
+
+    let state = AppState { manifest };
     let app = Router::new()
         .route("/query", post(query_handler))
         .route("/health", axum::routing::get(|| async { "ok" }))
         .with_state(state);
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}")).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))
+        .await
+        .unwrap();
     tracing::info!("listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+
+    tokio::select! {
+        _ = axum::serve(listener, app) => {}
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!("ctrl-c received, shutting down");
+            let _ = shutdown_tx.send(());
+            // Give the consumer time to drain its buffer before exiting.
+            tokio::time::sleep(Duration::from_secs(3)).await;
+        }
+    }
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -162,7 +195,8 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use event_schema::{AttributeValue, Level};
+    use event_schema::{AttributeValue, Level, LogEvent};
+    use server::flush_events;
     use std::collections::HashMap;
     use tower::util::ServiceExt;
 
@@ -363,5 +397,87 @@ mod tests {
         assert_eq!(rows.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
 
         store.delete(&obj_path).await.unwrap();
+    }
+
+    /// Full ingest → store → query via real Kafka.
+    /// Requires the Docker Compose stack: `make up`
+    /// Run with: cargo test -p server -- --ignored
+    #[tokio::test]
+    #[ignore]
+    async fn kafka_ingest_and_query() {
+        use rdkafka::config::ClientConfig;
+        use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
+        use std::time::Duration;
+
+        const TOPIC: &str = "logs-test-integration";
+        const N: usize = 10;
+
+        // Publish N synthetic events to a dedicated test topic.
+        let producer: BaseProducer = ClientConfig::new()
+            .set("bootstrap.servers", "localhost:9092")
+            .set("message.timeout.ms", "5000")
+            .create()
+            .unwrap();
+
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i64;
+
+        for i in 0..N {
+            let event = serde_json::json!({
+                "timestamp": now_ns + i as i64,
+                "level": "INFO",
+                "service": "integration-test",
+                "message": "kafka ingest test",
+                "kafka_partition": 0,
+                "kafka_offset": i,
+                "attributes": { "seq": i }
+            });
+            producer
+                .send(BaseRecord::to(TOPIC).payload(&event.to_string()).key(&format!("{i}")))
+                .expect("send failed");
+        }
+        producer.flush(Duration::from_secs(5)).unwrap();
+
+        // Start the consumer and let it run long enough to flush.
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        let manifest = Arc::new(Mutex::new(
+            Manifest::open(&dir.path().join("manifest.db")).unwrap(),
+        ));
+        let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
+
+        let consumer_manifest = Arc::clone(&manifest);
+        let consumer_data_dir = data_dir.clone();
+        tokio::spawn(async move {
+            let _ = run_consumer(
+                ConsumerConfig {
+                    bootstrap_servers: "localhost:9092".to_string(),
+                    group_id: format!("test-{}", uuid::Uuid::new_v4()),
+                    topic: TOPIC.to_string(),
+                },
+                consumer_data_dir,
+                consumer_manifest,
+                shutdown_rx,
+            )
+            .await;
+        });
+
+        // Wait for the time trigger (1s) plus buffer.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = shutdown_tx.send(());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Query and assert all N events are present.
+        let state = AppState { manifest };
+        let req = QueryRequest {
+            sql: "SELECT * FROM logs".to_string(),
+            time_from: Some(0),
+            time_to: Some(i64::MAX),
+            limit: 1000,
+        };
+        let rows = run_query(state, req).await.unwrap();
+        assert_eq!(rows.len(), N, "expected {N} events, got {}", rows.len());
     }
 }


### PR DESCRIPTION
## Summary
- Adds `server/src/consumer.rs` with `run_consumer()` — subscribes to the `logs` topic, deserializes JSON events, feeds them through `BatchBuffer`, and flushes to Parquet when any trigger fires (size / count / time)
- The time trigger is checked every 100ms via `tokio::select!` on an interval ticker
- On `ctrl-c`, the buffer is drained before exit so in-flight events are not lost
- `main()` spawns the consumer as a background task sharing the same `Arc<Mutex<Manifest>>` as the HTTP server
- `KAFKA_BROKERS`, `KAFKA_GROUP_ID`, `KAFKA_TOPIC`, and `DATA_DIR` are all env-configurable
- `auto.commit = true` for now — issue #9 changes this to manual commit strictly after a successful Parquet flush

## How to test manually
```bash
make up          # start Redpanda + MinIO + Prometheus + Grafana
make seed        # publish 1000 synthetic events to the logs topic
cargo run --bin server

# wait ~2s for the time trigger to flush, then query
curl -s -X POST localhost:8080/query \
  -H 'Content-Type: application/json' \
  -d '{"sql":"SELECT service, count(*) as n FROM logs GROUP BY service","time_from":0,"time_to":9223372036854775807}' | jq
```

## Automated tests
- [x] `kafka_ingest_and_query` — `#[ignore]`, requires `make up`; publishes 10 events, runs consumer for 3s, asserts 10 rows returned from `/query`
- [x] All 4 existing server tests still pass

## What's out of scope
- **Manual offset commit after flush** — issue #9; currently uses `auto.commit = true` which can lose events on crash
- **Per-partition workers** — all partitions are consumed in one loop; the per-partition worker model is a later issue
- **Backpressure** — `rdkafka` pause/resume based on buffer occupancy is issue #10

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)