### PR TITLE
feat: commit Kafka offsets only after successful Parquet flush (#9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,6 +2938,7 @@ dependencies = [
  "manifest",
  "object_store",
  "parquet",
+ "rdkafka",
  "serde",
  "serde_json",
  "storage",

--- a/server/src/consumer.rs
+++ b/server/src/consumer.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -6,8 +7,9 @@ use anyhow::Result;
 use batch_buffer::BatchBuffer;
 use event_schema::LogEvent;
 use manifest::Manifest;
-use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
 use rdkafka::message::Message;
+use rdkafka::topic_partition_list::{Offset, TopicPartitionList};
 use rdkafka::ClientConfig;
 use tokio::sync::{broadcast, Mutex};
 use tokio::time::interval;
@@ -35,12 +37,11 @@ impl Default for ConsumerConfig {
 
 /// Run the Kafka consumer loop until a shutdown signal is received.
 ///
-/// Events are deserialized from JSON, fed into a BatchBuffer, and flushed to
-/// Parquet when any trigger fires (size / record count / time). On shutdown the
-/// buffer is drained so in-flight events are not lost.
-///
-/// Note: auto.commit is enabled here for simplicity. Issue #9 changes this to
-/// manual offset commit strictly after a successful Parquet flush.
+/// Offsets are committed manually, strictly after a successful Parquet flush
+/// and manifest commit (at-least-once delivery). If the process crashes before
+/// a flush completes, uncommitted events are re-consumed from Kafka on restart.
+/// Duplicates in the re-consumed window are removed at query time via
+/// (kafka_partition, kafka_offset) deduplication (issue #14).
 pub async fn run_consumer(
     config: ConsumerConfig,
     data_dir: PathBuf,
@@ -51,13 +52,17 @@ pub async fn run_consumer(
         .set("bootstrap.servers", &config.bootstrap_servers)
         .set("group.id", &config.group_id)
         .set("auto.offset.reset", "earliest")
-        .set("enable.auto.commit", "true")
+        .set("enable.auto.commit", "false")
+        .set("enable.auto.offset.store", "false")
         .create()?;
 
     consumer.subscribe(&[&config.topic])?;
     tracing::info!("consumer subscribed to topic '{}'", config.topic);
 
     let mut buffer = BatchBuffer::with_defaults();
+    // Tracks the next-to-read offset (last consumed + 1) per (topic, partition).
+    // Reset after each successful commit so stale offsets are never re-committed.
+    let mut pending: HashMap<(String, i32), i64> = HashMap::new();
     let mut tick = interval(Duration::from_millis(100));
 
     loop {
@@ -70,13 +75,20 @@ pub async fn run_consumer(
                         match serde_json::from_slice::<LogEvent>(payload) {
                             Err(e) => tracing::warn!("failed to deserialize message: {e}"),
                             Ok(mut event) => {
-                                // Override with actual Kafka metadata — the producer's
-                                // embedded values may not match the assigned offset.
                                 event.kafka_partition = m.partition();
                                 event.kafka_offset = m.offset();
 
+                                // Record next-to-read offset for this partition.
+                                pending.insert(
+                                    (m.topic().to_string(), m.partition()),
+                                    m.offset() + 1,
+                                );
+
                                 if let Some(batch) = buffer.push(event) {
-                                    do_flush(&batch, &data_dir, &manifest).await;
+                                    if do_flush(&batch, &data_dir, &manifest).await {
+                                        commit_offsets(&consumer, &pending);
+                                        pending.clear();
+                                    }
                                 }
                             }
                         }
@@ -85,7 +97,10 @@ pub async fn run_consumer(
             }
             _ = tick.tick() => {
                 if let Some(batch) = buffer.poll() {
-                    do_flush(&batch, &data_dir, &manifest).await;
+                    if do_flush(&batch, &data_dir, &manifest).await {
+                        commit_offsets(&consumer, &pending);
+                        pending.clear();
+                    }
                 }
             }
             _ = shutdown.recv() => {
@@ -94,7 +109,9 @@ pub async fn run_consumer(
                     buffer.len()
                 );
                 if !buffer.is_empty() {
-                    do_flush(&buffer.drain(), &data_dir, &manifest).await;
+                    if do_flush(&buffer.drain(), &data_dir, &manifest).await {
+                        commit_offsets(&consumer, &pending);
+                    }
                 }
                 break;
             }
@@ -104,10 +121,37 @@ pub async fn run_consumer(
     Ok(())
 }
 
-async fn do_flush(batch: &[LogEvent], data_dir: &PathBuf, manifest: &Arc<Mutex<Manifest>>) {
+/// Flush a batch to Parquet + manifest. Returns true on success.
+async fn do_flush(batch: &[LogEvent], data_dir: &PathBuf, manifest: &Arc<Mutex<Manifest>>) -> bool {
     let mut guard = manifest.lock().await;
     match flush_events(batch, data_dir, &mut guard) {
-        Ok(path) => tracing::info!("flushed {} events → {}", batch.len(), path.display()),
-        Err(e) => tracing::error!("flush failed: {e:#}"),
+        Ok(path) => {
+            tracing::info!("flushed {} events → {}", batch.len(), path.display());
+            true
+        }
+        Err(e) => {
+            tracing::error!("flush failed: {e:#}");
+            false
+        }
+    }
+}
+
+/// Commit the pending offsets to Kafka synchronously.
+/// Called only after a confirmed successful flush.
+fn commit_offsets(consumer: &StreamConsumer, pending: &HashMap<(String, i32), i64>) {
+    if pending.is_empty() {
+        return;
+    }
+    let mut tpl = TopicPartitionList::new();
+    for ((topic, partition), offset) in pending {
+        if let Err(e) = tpl.add_partition_offset(topic, *partition, Offset::Offset(*offset)) {
+            tracing::error!("failed to build offset list: {e}");
+            return;
+        }
+    }
+    if let Err(e) = consumer.commit(&tpl, CommitMode::Sync) {
+        tracing::error!("offset commit failed: {e}");
+    } else {
+        tracing::debug!("committed offsets for {} partition(s)", pending.len());
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -480,4 +480,153 @@ mod tests {
         let rows = run_query(state, req).await.unwrap();
         assert_eq!(rows.len(), N, "expected {N} events, got {}", rows.len());
     }
+
+    /// After a successful flush, a second consumer with the same group ID must not
+    /// re-consume events — proves offsets were committed.
+    /// Requires: `make up`
+    #[tokio::test]
+    #[ignore]
+    async fn committed_offsets_not_reprocessed_after_flush() {
+        use rdkafka::config::ClientConfig;
+        use rdkafka::consumer::{Consumer, StreamConsumer};
+        use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
+        use std::time::Duration;
+
+        let topic = format!("test-committed-{}", uuid::Uuid::new_v4());
+        let group_id = format!("grp-{}", uuid::Uuid::new_v4());
+        const N: usize = 5;
+
+        let producer: BaseProducer = ClientConfig::new()
+            .set("bootstrap.servers", "localhost:9092")
+            .set("message.timeout.ms", "5000")
+            .create().unwrap();
+
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos() as i64;
+
+        for i in 0..N {
+            let event = serde_json::json!({
+                "timestamp": now_ns + i as i64, "level": "INFO",
+                "service": "commit-test", "message": "commit test",
+                "kafka_partition": 0, "kafka_offset": i, "attributes": {}
+            });
+            producer.send(BaseRecord::to(&topic).payload(&event.to_string()).key(&format!("{i}"))).unwrap();
+        }
+        producer.flush(Duration::from_secs(5)).unwrap();
+
+        // First consumer: flushes events and commits offsets.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = Arc::new(Mutex::new(Manifest::open(&dir.path().join("manifest.db")).unwrap()));
+        let (tx, rx) = tokio::sync::broadcast::channel::<()>(1);
+        let m2 = Arc::clone(&manifest);
+        let data_dir = dir.path().join("data");
+        let dd = data_dir.clone();
+        let gid = group_id.clone();
+        let top = topic.clone();
+        tokio::spawn(async move {
+            let _ = run_consumer(ConsumerConfig {
+                bootstrap_servers: "localhost:9092".to_string(),
+                group_id: gid, topic: top,
+            }, dd, m2, rx).await;
+        });
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = tx.send(());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Second consumer with the same group ID: should see no messages because
+        // offsets were committed to the end of the topic.
+        let second: StreamConsumer = ClientConfig::new()
+            .set("bootstrap.servers", "localhost:9092")
+            .set("group.id", &group_id)
+            .set("auto.offset.reset", "earliest")
+            .set("enable.auto.commit", "false")
+            .create().unwrap();
+        second.subscribe(&[topic.as_str()]).unwrap();
+
+        // Allow time for partition assignment, then assert no messages arrive.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let result = tokio::time::timeout(Duration::from_secs(2), second.recv()).await;
+        assert!(result.is_err(), "second consumer received a message — offsets were not committed");
+    }
+
+    /// A consumer that crashes without committing offsets must cause the next
+    /// consumer (same group) to re-consume and re-flush those events — proves
+    /// at-least-once delivery.
+    /// Requires: `make up`
+    #[tokio::test]
+    #[ignore]
+    async fn uncommitted_offsets_reprocessed_on_restart() {
+        use rdkafka::config::ClientConfig;
+        use rdkafka::consumer::{Consumer, StreamConsumer};
+        use rdkafka::producer::{BaseProducer, BaseRecord, Producer};
+        use rdkafka::message::Message;
+        use std::time::Duration;
+
+        let topic = format!("test-reprocess-{}", uuid::Uuid::new_v4());
+        let group_id = format!("grp-{}", uuid::Uuid::new_v4());
+        const N: usize = 5;
+
+        let producer: BaseProducer = ClientConfig::new()
+            .set("bootstrap.servers", "localhost:9092")
+            .set("message.timeout.ms", "5000")
+            .create().unwrap();
+
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos() as i64;
+
+        for i in 0..N {
+            let event = serde_json::json!({
+                "timestamp": now_ns + i as i64, "level": "INFO",
+                "service": "reprocess-test", "message": "reprocess test",
+                "kafka_partition": 0, "kafka_offset": i, "attributes": {}
+            });
+            producer.send(BaseRecord::to(&topic).payload(&event.to_string()).key(&format!("{i}"))).unwrap();
+        }
+        producer.flush(Duration::from_secs(5)).unwrap();
+
+        // Simulate crash: consume all N events but do NOT commit offsets.
+        {
+            let crasher: StreamConsumer = ClientConfig::new()
+                .set("bootstrap.servers", "localhost:9092")
+                .set("group.id", &group_id)
+                .set("auto.offset.reset", "earliest")
+                .set("enable.auto.commit", "false")
+                .set("enable.auto.offset.store", "false")
+                .create().unwrap();
+            crasher.subscribe(&[topic.as_str()]).unwrap();
+            for _ in 0..N {
+                tokio::time::timeout(Duration::from_secs(5), crasher.recv())
+                    .await.expect("timed out waiting for message").unwrap();
+            }
+            // crasher dropped here without committing — simulates kill -9
+        }
+
+        // Recovery: run_consumer with the same group ID. Because no offsets were
+        // committed, it re-consumes all N events from the beginning.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = Arc::new(Mutex::new(Manifest::open(&dir.path().join("manifest.db")).unwrap()));
+        let (tx, rx) = tokio::sync::broadcast::channel::<()>(1);
+        let m2 = Arc::clone(&manifest);
+        let data_dir = dir.path().join("data");
+        let dd = data_dir.clone();
+        let gid = group_id.clone();
+        let top = topic.clone();
+        tokio::spawn(async move {
+            let _ = run_consumer(ConsumerConfig {
+                bootstrap_servers: "localhost:9092".to_string(),
+                group_id: gid, topic: top,
+            }, dd, m2, rx).await;
+        });
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = tx.send(());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // All N events must be present — none were permanently lost.
+        let state = AppState { manifest };
+        let rows = run_query(state, QueryRequest {
+            sql: "SELECT * FROM logs".to_string(),
+            time_from: Some(0), time_to: Some(i64::MAX), limit: 1000,
+        }).await.unwrap();
+        assert_eq!(rows.len(), N, "expected {N} events after re-consumption, got {}", rows.len());
+    }
 }


### PR DESCRIPTION
## Summary
- Disables `enable.auto.commit` and `enable.auto.offset.store` — the consumer now owns offset lifecycle completely
- Tracks the next-to-read offset (last consumed + 1) per `(topic, partition)` in a `HashMap` as events are consumed
- After each successful `flush_events` + manifest commit, commits the tracked offsets synchronously via `TopicPartitionList` and clears the map
- If flush fails, offsets are left uncommitted — events will be re-consumed from Kafka on restart (at-least-once delivery)
- Duplicates introduced by re-consumption are handled at query time via `(kafka_partition, kafka_offset)` deduplication (issue #14)
- On shutdown, the buffer is drained, flushed, and offsets committed before exit

## Crash recovery behaviour
| Crash timing | On restart |
|---|---|
| Before flush completes | Re-consumes events from last committed offset — no data lost |
| After flush, before commit | Re-consumes and re-flushes the same events — duplicates, handled by #14 |
| After commit | Starts from next uncommitted offset — no re-consumption |

## Test plan
- [x] All 4 existing server unit tests still pass
- [x] Manual: `make seed` → start server → kill with `kill -9` mid-run → restart → query → all events present
- [x] `kafka_ingest_and_query` (`#[ignore]`) still passes end-to-end

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)