### PR TITLE
feat(#15): cold tier write path — tiering policy and manifest tier field

### DIFF
--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -93,6 +93,58 @@ impl Manifest {
         Ok(self.conn.last_insert_rowid())
     }
 
+    /// Return active hot-tier files whose max_ts is strictly before `cutoff_ns`.
+    pub fn hot_files_older_than(&self, cutoff_ns: i64) -> Result<Vec<FileEntry>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, path, tier, service, time_bucket, min_ts, max_ts,
+                        size_bytes, record_count, state, min_kafka_offset, max_kafka_offset
+                 FROM files WHERE state = 'active' AND tier = 'hot' AND max_ts < ?1",
+            )
+            .context("prepare hot_files_older_than")?;
+        let rows = stmt
+            .query_map(params![cutoff_ns], map_row)
+            .context("query hot_files_older_than")?
+            .collect::<std::result::Result<_, _>>()
+            .context("collect rows")?;
+        Ok(rows)
+    }
+
+    /// Promote a file to the cold tier, updating its path to the object-store URI.
+    /// This is atomic: tier and path change in a single UPDATE.
+    pub fn set_cold(&mut self, id: i64, cold_path: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "UPDATE files SET tier = 'cold', path = ?1 WHERE id = ?2",
+                params![cold_path, id],
+            )
+            .context("set_cold")?;
+        Ok(())
+    }
+
+    /// Count active files grouped by tier. Returns (hot_count, cold_count).
+    pub fn count_active_by_tier(&self) -> Result<(u64, u64)> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT tier, COUNT(*) FROM files WHERE state = 'active' GROUP BY tier")
+            .context("prepare count_active_by_tier")?;
+        let mut hot = 0u64;
+        let mut cold = 0u64;
+        let rows = stmt
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)))
+            .context("query count_active_by_tier")?;
+        for row in rows {
+            let (tier, count) = row.context("read tier count row")?;
+            match tier.as_str() {
+                "hot" => hot = count as u64,
+                "cold" => cold = count as u64,
+                _ => {}
+            }
+        }
+        Ok((hot, cold))
+    }
+
     /// Return paths of all active files, optionally filtered by service.
     pub fn active_files(&self, service: Option<&str>) -> Result<Vec<FileEntry>> {
         let mut stmt = if let Some(svc) = service {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,5 +1,7 @@
 pub use consumer::{run_consumer, ConsumerConfig};
 pub use flush::flush_events;
+pub use tier::{run_tiering, TieringConfig};
 
 mod consumer;
 mod flush;
+pub mod tier;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -19,7 +19,8 @@ use datafusion::prelude::*;
 use futures::{channel::mpsc, StreamExt};
 use manifest::Manifest;
 use serde::Deserialize;
-use server::{run_consumer, ConsumerConfig};
+use server::{run_consumer, run_tiering, ConsumerConfig, TieringConfig};
+use storage::MinioConfig;
 use tokio::sync::{broadcast, Mutex, Semaphore};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -77,7 +78,10 @@ async fn stream_query(
 ) -> Result<impl futures::Stream<Item = Result<Bytes, BoxError>> + Send + 'static> {
     let files = {
         let guard = state.manifest.lock().await;
-        guard.active_files(None)?
+        // Cold-tier files have object store URIs that DataFusion cannot read without
+        // a registered object store. Restrict to hot-only until issue #22 (cross-tier
+        // queries) is implemented.
+        guard.active_files(None)?.into_iter().filter(|f| f.tier == "hot").collect::<Vec<_>>()
     };
 
     let time_from = req.time_from.unwrap();
@@ -241,7 +245,7 @@ async fn main() {
         Manifest::open(Path::new(&db_path)).expect("open manifest"),
     ));
 
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
+    let (shutdown_tx, _) = broadcast::channel::<()>(1);
 
     let max_concurrent_flushes = std::env::var("MAX_CONCURRENT_FLUSHES")
         .ok()
@@ -252,6 +256,7 @@ async fn main() {
     // Start Kafka consumer as a background task.
     let consumer_manifest = Arc::clone(&manifest);
     let consumer_semaphore = Arc::clone(&flush_semaphore);
+    let consumer_shutdown = shutdown_tx.subscribe();
     tokio::spawn(async move {
         if let Err(e) = run_consumer(
             ConsumerConfig::default(),
@@ -259,11 +264,40 @@ async fn main() {
             consumer_manifest,
             Arc::new(AtomicU64::new(0)),
             consumer_semaphore,
-            shutdown_rx,
+            consumer_shutdown,
         )
         .await
         {
             tracing::error!("consumer exited with error: {e:#}");
+        }
+    });
+
+    // Start background tiering task.
+    let tiering_manifest = Arc::clone(&manifest);
+    let tiering_shutdown = shutdown_tx.subscribe();
+    let tiering_config = TieringConfig {
+        minio: MinioConfig {
+            endpoint: std::env::var("MINIO_ENDPOINT")
+                .unwrap_or_else(|_| "http://localhost:9000".to_string()),
+            access_key: std::env::var("MINIO_ACCESS_KEY")
+                .unwrap_or_else(|_| "minioadmin".to_string()),
+            secret_key: std::env::var("MINIO_SECRET_KEY")
+                .unwrap_or_else(|_| "minioadmin".to_string()),
+            bucket: std::env::var("MINIO_BUCKET")
+                .unwrap_or_else(|_| "logs".to_string()),
+        },
+        threshold_days: std::env::var("TIER_THRESHOLD_DAYS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(7),
+        interval_secs: std::env::var("TIER_INTERVAL_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(60),
+    };
+    tokio::spawn(async move {
+        if let Err(e) = run_tiering(tiering_config, tiering_manifest, tiering_shutdown).await {
+            tracing::error!("tiering task exited with error: {e:#}");
         }
     });
 
@@ -1108,6 +1142,79 @@ mod tests {
             .map(|r| r["kafka_offset"].as_i64().unwrap())
             .collect();
         assert_eq!(offsets.len(), N, "duplicate events detected after rebalance");
+    }
+
+    /// Flush events, then run tiering with threshold_days=0 so all hot files are immediately
+    /// eligible. Assert the file appears in MinIO and is removed locally.
+    /// Requires MinIO running: `make up`
+    /// Run with: cargo test -p server -- --ignored
+    #[tokio::test]
+    #[ignore]
+    async fn tiering_moves_hot_files_to_minio() {
+        use object_store::path::Path as ObjPath;
+        use server::{run_tiering, TieringConfig};
+        use storage::{minio_store, MinioConfig};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("manifest.db");
+        let data_dir = dir.path().join("data");
+
+        let event = make_event();
+        let mut manifest = Manifest::open(&db_path).unwrap();
+        flush_events(&[event], &data_dir, &mut manifest).unwrap();
+
+        let hot_files = manifest.active_files(None).unwrap();
+        assert_eq!(hot_files.len(), 1);
+        let hot_path = hot_files[0].path.clone();
+        assert!(
+            std::path::Path::new(&hot_path).exists(),
+            "hot file must exist before tiering"
+        );
+
+        let manifest = Arc::new(Mutex::new(manifest));
+        let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
+
+        // threshold_days=0 → cutoff = now, so any file with max_ts < now is eligible.
+        // interval_secs=0 → sleep resolves immediately; first pass fires right away.
+        let tiering_config = TieringConfig {
+            minio: MinioConfig::default(),
+            threshold_days: 0,
+            interval_secs: 0,
+        };
+
+        let tiering_manifest = Arc::clone(&manifest);
+        let handle = tokio::spawn(async move {
+            run_tiering(tiering_config, tiering_manifest, shutdown_rx).await
+        });
+
+        // Allow at least one tiering pass to complete, then shut down.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let _ = shutdown_tx.send(());
+        handle.await.unwrap().unwrap();
+
+        // Local file must be gone.
+        assert!(
+            !std::path::Path::new(&hot_path).exists(),
+            "local file must be removed after tiering"
+        );
+
+        // Manifest must reflect the file as cold with an S3 URI.
+        let files = manifest.lock().await.active_files(None).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].tier, "cold");
+        assert!(files[0].path.starts_with("s3://"), "cold path must be an S3 URI");
+
+        // File must be readable from MinIO.
+        let minio_config = MinioConfig::default();
+        let store = minio_store(&minio_config).unwrap();
+        let cold_key = files[0].path
+            .strip_prefix(&format!("s3://{}/", minio_config.bucket))
+            .expect("cold path must start with bucket prefix");
+        let obj_path = ObjPath::from(cold_key);
+        store.get(&obj_path).await.expect("file must be readable from MinIO");
+
+        // Cleanup MinIO object so repeated test runs don't accumulate objects.
+        store.delete(&obj_path).await.unwrap();
     }
 
     /// Verify that buffer backpressure pauses and resumes the Kafka consumer without

--- a/server/src/tier.rs
+++ b/server/src/tier.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use storage::object_store::path::Path as ObjPath;
+use tokio::sync::{broadcast, Mutex};
+
+use manifest::Manifest;
+use storage::{minio_store, MinioConfig};
+
+pub struct TieringConfig {
+    pub minio: MinioConfig,
+    /// Files with max_ts older than this many days are moved to cold storage.
+    pub threshold_days: u64,
+    /// How often the tiering task wakes to scan for eligible files.
+    pub interval_secs: u64,
+}
+
+impl Default for TieringConfig {
+    fn default() -> Self {
+        Self {
+            minio: MinioConfig::default(),
+            threshold_days: 7,
+            interval_secs: 60,
+        }
+    }
+}
+
+pub async fn run_tiering(
+    config: TieringConfig,
+    manifest: Arc<Mutex<Manifest>>,
+    mut shutdown: broadcast::Receiver<()>,
+) -> Result<()> {
+    let store = minio_store(&config.minio)?;
+    let threshold_ns = config.threshold_days as i64 * 24 * 3600 * 1_000_000_000i64;
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.recv() => return Ok(()),
+            _ = tokio::time::sleep(Duration::from_secs(config.interval_secs)) => {}
+        }
+
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as i64;
+        let cutoff_ns = now_ns.saturating_sub(threshold_ns);
+
+        let eligible = {
+            let m = manifest.lock().await;
+            m.hot_files_older_than(cutoff_ns)?
+        };
+
+        for file in eligible {
+            if let Err(e) = tier_file(&file, &store, &config.minio.bucket, &manifest).await {
+                tracing::warn!(path = %file.path, "tiering failed: {e:#}");
+            }
+        }
+
+        // Refresh files_active gauge after each pass.
+        let (hot, cold) = {
+            let m = manifest.lock().await;
+            m.count_active_by_tier()?
+        };
+        metrics::gauge!("files_active", "tier" => "hot").set(hot as f64);
+        metrics::gauge!("files_active", "tier" => "cold").set(cold as f64);
+    }
+}
+
+async fn tier_file(
+    file: &manifest::FileEntry,
+    store: &Arc<dyn storage::object_store::ObjectStore>,
+    bucket: &str,
+    manifest: &Arc<Mutex<Manifest>>,
+) -> Result<()> {
+    let local_path = std::path::Path::new(&file.path);
+    let filename = local_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .with_context(|| format!("invalid local path: {}", file.path))?;
+
+    let cold_key = format!("{}/{}/{}", file.service, file.time_bucket, filename);
+    let cold_uri = format!("s3://{bucket}/{cold_key}");
+
+    // 1. Read and upload — file still exists locally.
+    let bytes = tokio::fs::read(local_path)
+        .await
+        .with_context(|| format!("read {}", file.path))?;
+    store
+        .put(&ObjPath::from(cold_key.as_str()), Bytes::from(bytes).into())
+        .await
+        .with_context(|| format!("upload to MinIO: {cold_key}"))?;
+
+    // 2. Update manifest atomically (tier + path in one UPDATE).
+    //    File is now recorded as cold; it still exists locally as a redundant copy.
+    {
+        let mut m = manifest.lock().await;
+        m.set_cold(file.id, &cold_uri)
+            .with_context(|| format!("set_cold id={}", file.id))?;
+    }
+
+    // 3. Delete the local copy now that the manifest points to cold storage.
+    tokio::fs::remove_file(local_path)
+        .await
+        .with_context(|| format!("delete local {}", file.path))?;
+
+    tracing::info!(id = file.id, local = %file.path, cold = %cold_uri, "tiered to cold");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds `hot_files_older_than`, `set_cold`, and `count_active_by_tier` to the manifest (`crates/manifest`)
- Implements `run_tiering` background task (`server/src/tier.rs`): reads eligible hot files, copies each to MinIO, atomically updates the manifest (`tier=cold`, `path=s3://...`), then deletes the local copy — ensuring the file is never absent from both tiers simultaneously
- Wires the tiering task in `main()` with env-var config (`MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`, `TIER_THRESHOLD_DAYS`, `TIER_INTERVAL_SECS`)
- Filters `stream_query` to hot-only files until issue #22 (cross-tier DataFusion queries) is implemented
- Emits `files_active{tier="hot"}` and `files_active{tier="cold"}` Prometheus gauges after each tiering pass
- Adds `#[ignore]` integration test: flush an event → run tiering with `threshold_days=0` → assert file appears in MinIO and is removed locally

## Test plan

- [ ] All non-ignored tests pass: `cargo test -p server`
- [ ] Manual: `make up && cargo test -p server -- --ignored tiering_moves_hot_files_to_minio`

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)