### PR TITLE
feat(#18): compaction worker — merge, sort, dedup, atomic manifest swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -2007,6 +2009,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -3076,6 +3087,7 @@ dependencies = [
  "datafusion",
  "event-schema",
  "futures",
+ "lru",
  "manifest",
  "metrics",
  "metrics-exporter-prometheus",

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -145,6 +145,86 @@ impl Manifest {
         Ok((hot, cold))
     }
 
+    /// Return (service, time_bucket) pairs that have at least `min_files` hot active files.
+    pub fn compactable_buckets(&self, min_files: usize) -> Result<Vec<(String, String)>> {
+        let min = min_files as i64;
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT service, time_bucket FROM files
+                 WHERE state = 'active' AND tier = 'hot'
+                 GROUP BY service, time_bucket
+                 HAVING COUNT(*) >= ?1",
+            )
+            .context("prepare compactable_buckets")?;
+        let rows = stmt
+            .query_map(params![min], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .context("query compactable_buckets")?
+            .collect::<std::result::Result<_, _>>()
+            .context("collect rows")?;
+        Ok(rows)
+    }
+
+    /// Return all active hot files for a given (service, time_bucket).
+    pub fn active_hot_files_for_bucket(
+        &self,
+        service: &str,
+        time_bucket: &str,
+    ) -> Result<Vec<FileEntry>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, path, tier, service, time_bucket, min_ts, max_ts,
+                        size_bytes, record_count, state, min_kafka_offset, max_kafka_offset
+                 FROM files
+                 WHERE state = 'active' AND tier = 'hot'
+                   AND service = ?1 AND time_bucket = ?2",
+            )
+            .context("prepare active_hot_files_for_bucket")?;
+        let rows = stmt
+            .query_map(params![service, time_bucket], map_row)
+            .context("query active_hot_files_for_bucket")?
+            .collect::<std::result::Result<_, _>>()
+            .context("collect rows")?;
+        Ok(rows)
+    }
+
+    /// Atomic compaction swap: insert new compacted files and mark old files superseded.
+    /// No window where data is missing — old files remain active until commit.
+    pub fn swap_compacted(&mut self, old_ids: &[i64], new_files: &[FlushMeta]) -> Result<()> {
+        let tx = self.conn.transaction().context("begin compaction transaction")?;
+        for meta in new_files {
+            tx.execute(
+                "INSERT INTO files
+                    (path, service, time_bucket, min_ts, max_ts,
+                     size_bytes, record_count, min_kafka_offset, max_kafka_offset)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    meta.path,
+                    meta.service,
+                    meta.time_bucket,
+                    meta.min_ts,
+                    meta.max_ts,
+                    meta.size_bytes,
+                    meta.record_count,
+                    meta.min_kafka_offset,
+                    meta.max_kafka_offset,
+                ],
+            )
+            .context("insert compacted file")?;
+        }
+        for &id in old_ids {
+            tx.execute(
+                "UPDATE files SET state = 'superseded' WHERE id = ?1",
+                params![id],
+            )
+            .context("mark file superseded")?;
+        }
+        tx.commit().context("commit compaction swap")
+    }
+
     /// Return paths of all active files, optionally filtered by service.
     pub fn active_files(&self, service: Option<&str>) -> Result<Vec<FileEntry>> {
         let mut stmt = if let Some(svc) = service {

--- a/server/src/compact.rs
+++ b/server/src/compact.rs
@@ -1,0 +1,247 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use arrow::array::Int64Array;
+use arrow::record_batch::RecordBatch;
+use datafusion::prelude::*;
+use manifest::{FlushMeta, Manifest};
+use parquet::arrow::ArrowWriter;
+use tokio::sync::{broadcast, Mutex};
+use uuid::Uuid;
+
+pub struct CompactionConfig {
+    pub data_dir: PathBuf,
+    /// Minimum number of hot active files per (service, time_bucket) to trigger compaction.
+    pub min_files_per_bucket: usize,
+    /// Target IPC byte size per output file used to decide when to split. Default: 64 MiB.
+    /// Parquet compression means the on-disk file is typically 30–60 % of this value,
+    /// landing in the 32–128 MiB target range for typical log schemas.
+    pub target_file_bytes: u64,
+    /// How often the compaction task wakes to scan for eligible buckets.
+    pub interval_secs: u64,
+}
+
+impl Default for CompactionConfig {
+    fn default() -> Self {
+        Self {
+            data_dir: PathBuf::from("data"),
+            min_files_per_bucket: 2,
+            target_file_bytes: 64 * 1024 * 1024,
+            interval_secs: 1800,
+        }
+    }
+}
+
+pub async fn run_compaction(
+    config: CompactionConfig,
+    manifest: Arc<Mutex<Manifest>>,
+    mut shutdown: broadcast::Receiver<()>,
+) -> Result<()> {
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.recv() => return Ok(()),
+            _ = tokio::time::sleep(Duration::from_secs(config.interval_secs)) => {}
+        }
+
+        let buckets = {
+            let m = manifest.lock().await;
+            m.compactable_buckets(config.min_files_per_bucket)?
+        };
+
+        for (service, time_bucket) in buckets {
+            if let Err(e) = compact_bucket(&service, &time_bucket, &config, &manifest).await {
+                tracing::warn!(service = %service, bucket = %time_bucket, "compaction failed: {e:#}");
+            }
+        }
+    }
+}
+
+/// Compact all hot active files for one (service, time_bucket).
+/// Public so it can be called directly in tests.
+pub async fn compact_bucket(
+    service: &str,
+    time_bucket: &str,
+    config: &CompactionConfig,
+    manifest: &Arc<Mutex<Manifest>>,
+) -> Result<()> {
+    let files = {
+        let m = manifest.lock().await;
+        m.active_hot_files_for_bucket(service, time_bucket)?
+    };
+
+    if files.len() < 2 {
+        return Ok(());
+    }
+
+    let old_ids: Vec<i64> = files.iter().map(|f| f.id).collect();
+
+    // Sort all rows by timestamp and deduplicate by (kafka_partition, kafka_offset),
+    // keeping the earliest copy of each unique key — same window function used at
+    // query time, now applied once permanently.
+    let ctx = SessionContext::new();
+    for (i, entry) in files.iter().enumerate() {
+        ctx.register_parquet(&format!("_f{i}"), &entry.path, ParquetReadOptions::default())
+            .await
+            .with_context(|| format!("register {}", entry.path))?;
+    }
+
+    let union_sql = (0..files.len())
+        .map(|i| format!("SELECT * FROM _f{i}"))
+        .collect::<Vec<_>>()
+        .join(" UNION ALL ");
+    let compact_sql = format!(
+        "SELECT * EXCEPT (_rn) FROM (\
+            SELECT *, ROW_NUMBER() OVER \
+                (PARTITION BY kafka_partition, kafka_offset ORDER BY timestamp) AS _rn \
+            FROM ({union_sql})\
+        ) WHERE _rn = 1 \
+        ORDER BY timestamp"
+    );
+
+    let batches: Vec<RecordBatch> = ctx
+        .sql(&compact_sql)
+        .await
+        .context("plan compaction query")?
+        .collect()
+        .await
+        .context("execute compaction query")?;
+
+    if batches.is_empty() || batches.iter().all(|b| b.num_rows() == 0) {
+        return Ok(());
+    }
+
+    // Split into target-sized chunks and write each as a Parquet file.
+    let chunks = split_by_ipc_size(batches, config.target_file_bytes);
+    let mut new_files: Vec<FlushMeta> = Vec::with_capacity(chunks.len());
+    for chunk in &chunks {
+        let meta = write_chunk(chunk, service, time_bucket, &config.data_dir)
+            .context("write compacted chunk")?;
+        new_files.push(meta);
+    }
+
+    // Atomic swap: new files become active, old files become superseded in one transaction.
+    {
+        let mut m = manifest.lock().await;
+        m.swap_compacted(&old_ids, &new_files)
+            .context("swap_compacted")?;
+    }
+
+    // Best-effort deletion of the now-superseded local files.
+    for file in &files {
+        if let Err(e) = tokio::fs::remove_file(&file.path).await {
+            tracing::warn!(path = %file.path, "delete superseded file failed: {e}");
+        }
+    }
+
+    tracing::info!(
+        service = %service,
+        bucket = %time_bucket,
+        old_files = old_ids.len(),
+        new_files = new_files.len(),
+        "compaction complete"
+    );
+    Ok(())
+}
+
+/// Split a flat batch list into chunks where each chunk's IPC size stays under `target_bytes`.
+/// A single batch that exceeds `target_bytes` is kept as its own chunk.
+fn split_by_ipc_size(batches: Vec<RecordBatch>, target_bytes: u64) -> Vec<Vec<RecordBatch>> {
+    if batches.is_empty() {
+        return vec![];
+    }
+    let mut chunks: Vec<Vec<RecordBatch>> = Vec::new();
+    let mut current: Vec<RecordBatch> = Vec::new();
+    let mut current_bytes: u64 = 0;
+
+    for batch in batches {
+        let size = ipc_size(&batch);
+        if current_bytes + size > target_bytes && !current.is_empty() {
+            chunks.push(std::mem::take(&mut current));
+            current_bytes = 0;
+        }
+        current_bytes += size;
+        current.push(batch);
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
+}
+
+/// IPC stream byte size of a single RecordBatch (used as a proxy for Parquet file size).
+fn ipc_size(batch: &RecordBatch) -> u64 {
+    use arrow::ipc::writer::StreamWriter;
+    let mut buf = Vec::new();
+    if let Ok(mut w) = StreamWriter::try_new(&mut buf, &batch.schema()) {
+        w.write(batch).ok();
+        w.finish().ok();
+    }
+    buf.len() as u64
+}
+
+/// Write a chunk of sorted, deduplicated batches to a Parquet file. Returns the FlushMeta.
+fn write_chunk(
+    batches: &[RecordBatch],
+    service: &str,
+    time_bucket: &str,
+    data_dir: &Path,
+) -> Result<FlushMeta> {
+    let schema = batches[0].schema();
+    let dir = data_dir.join(service).join(time_bucket);
+    std::fs::create_dir_all(&dir).context("create compaction output dir")?;
+    let path = dir.join(format!("{}.parquet", Uuid::new_v4()));
+
+    let file = std::fs::File::create(&path).context("create compaction output file")?;
+    let mut writer =
+        ArrowWriter::try_new(file, schema, None).context("create ArrowWriter")?;
+    for batch in batches {
+        writer.write(batch).context("write batch to compaction file")?;
+    }
+    writer.close().context("close compaction writer")?;
+
+    let size_bytes = std::fs::metadata(&path)
+        .context("stat compaction file")?
+        .len() as i64;
+    let record_count: i64 = batches.iter().map(|b| b.num_rows() as i64).sum();
+
+    let (min_ts, max_ts) = col_min_max_i64(batches, "timestamp")?;
+    let (min_kafka_offset, max_kafka_offset) = col_min_max_i64(batches, "kafka_offset")?;
+
+    Ok(FlushMeta {
+        path: path.to_string_lossy().into_owned(),
+        service: service.to_string(),
+        time_bucket: time_bucket.to_string(),
+        min_ts,
+        max_ts,
+        size_bytes,
+        record_count,
+        min_kafka_offset,
+        max_kafka_offset,
+    })
+}
+
+fn col_min_max_i64(batches: &[RecordBatch], column: &str) -> Result<(i64, i64)> {
+    let mut min_val = i64::MAX;
+    let mut max_val = i64::MIN;
+    for batch in batches {
+        let idx = batch
+            .schema()
+            .index_of(column)
+            .with_context(|| format!("column '{column}' not found in compaction output"))?;
+        let arr = batch
+            .column(idx)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .with_context(|| format!("column '{column}' is not Int64"))?;
+        if let Some(v) = arrow::compute::min(arr) {
+            min_val = min_val.min(v);
+        }
+        if let Some(v) = arrow::compute::max(arr) {
+            max_val = max_val.max(v);
+        }
+    }
+    Ok((min_val, max_val))
+}

--- a/server/src/compact.rs
+++ b/server/src/compact.rs
@@ -195,8 +195,12 @@ fn write_chunk(
     let path = dir.join(format!("{}.parquet", Uuid::new_v4()));
 
     let file = std::fs::File::create(&path).context("create compaction output file")?;
+    // Explicitly enable page-level statistics so DataFusion can prune row groups using min/max.
+    let props = parquet::file::properties::WriterProperties::builder()
+        .set_statistics_enabled(parquet::file::properties::EnabledStatistics::Page)
+        .build();
     let mut writer =
-        ArrowWriter::try_new(file, schema, None).context("create ArrowWriter")?;
+        ArrowWriter::try_new(file, schema, Some(props)).context("create ArrowWriter")?;
     for batch in batches {
         writer.write(batch).context("write batch to compaction file")?;
     }
@@ -221,6 +225,55 @@ fn write_chunk(
         min_kafka_offset,
         max_kafka_offset,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    fn make_batch(n_rows: usize) -> RecordBatch {
+        let schema = std::sync::Arc::new(Schema::new(vec![Field::new("v", DataType::Int64, false)]));
+        let arr = Int64Array::from_iter_values(0..n_rows as i64);
+        RecordBatch::try_new(schema, vec![std::sync::Arc::new(arr)]).unwrap()
+    }
+
+    #[test]
+    fn split_by_ipc_size_splits_when_target_exceeded() {
+        let batch = make_batch(100);
+        let single_size = ipc_size(&batch);
+        assert!(single_size > 0);
+
+        // target less than one batch → each batch must be its own chunk
+        let chunks = split_by_ipc_size(
+            vec![batch.clone(), batch.clone(), batch.clone()],
+            single_size - 1,
+        );
+        assert_eq!(chunks.len(), 3, "each batch should be its own chunk when target < single batch size");
+        for chunk in &chunks {
+            assert_eq!(chunk.len(), 1);
+        }
+    }
+
+    #[test]
+    fn split_by_ipc_size_no_split_when_target_large() {
+        let batch = make_batch(100);
+        let single_size = ipc_size(&batch);
+
+        // target larger than 3 batches combined → all in one chunk
+        let chunks = split_by_ipc_size(
+            vec![batch.clone(), batch.clone(), batch.clone()],
+            single_size * 10,
+        );
+        assert_eq!(chunks.len(), 1, "all batches should be in one chunk when target is large");
+        assert_eq!(chunks[0].len(), 3);
+    }
+
+    #[test]
+    fn split_by_ipc_size_empty_input() {
+        let chunks = split_by_ipc_size(vec![], 1024);
+        assert!(chunks.is_empty());
+    }
 }
 
 fn col_min_max_i64(batches: &[RecordBatch], column: &str) -> Result<(i64, i64)> {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,7 +1,9 @@
+pub use compact::{compact_bucket, run_compaction, CompactionConfig};
 pub use consumer::{run_consumer, ConsumerConfig};
 pub use flush::flush_events;
 pub use tier::{run_tiering, TieringConfig};
 
+pub mod compact;
 mod consumer;
 mod flush;
 pub mod tier;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -20,10 +20,12 @@ use futures::{channel::mpsc, StreamExt};
 use manifest::Manifest;
 use serde::Deserialize;
 use cold_cache::ColdCache;
+use compact::{run_compaction, CompactionConfig};
 use server::{run_consumer, run_tiering, ConsumerConfig, TieringConfig};
 use storage::MinioConfig;
 
 mod cold_cache;
+mod compact;
 use tokio::sync::{broadcast, Mutex, Semaphore};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
@@ -270,6 +272,7 @@ async fn main() {
         std::env::var("DATA_DIR").unwrap_or_else(|_| "data".to_string()),
     );
     std::fs::create_dir_all(&data_dir).expect("create data dir");
+    let data_dir = data_dir; // keep owned before cloning into spawned tasks
 
     let db_path = std::env::var("MANIFEST_PATH").unwrap_or_else(|_| "manifest.db".to_string());
     let manifest = Arc::new(Mutex::new(
@@ -288,10 +291,11 @@ async fn main() {
     let consumer_manifest = Arc::clone(&manifest);
     let consumer_semaphore = Arc::clone(&flush_semaphore);
     let consumer_shutdown = shutdown_tx.subscribe();
+    let consumer_data_dir = data_dir.clone();
     tokio::spawn(async move {
         if let Err(e) = run_consumer(
             ConsumerConfig::default(),
-            data_dir,
+            consumer_data_dir,
             consumer_manifest,
             Arc::new(AtomicU64::new(0)),
             consumer_semaphore,
@@ -331,6 +335,32 @@ async fn main() {
     tokio::spawn(async move {
         if let Err(e) = run_tiering(tiering_config, tiering_manifest, tiering_shutdown).await {
             tracing::error!("tiering task exited with error: {e:#}");
+        }
+    });
+
+    // Start background compaction task.
+    let compaction_manifest = Arc::clone(&manifest);
+    let compaction_shutdown = shutdown_tx.subscribe();
+    let compaction_config = CompactionConfig {
+        data_dir: data_dir.clone(),
+        min_files_per_bucket: std::env::var("COMPACT_MIN_FILES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(2),
+        target_file_bytes: std::env::var("COMPACT_TARGET_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(64 * 1024 * 1024),
+        interval_secs: std::env::var("COMPACT_INTERVAL_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1800),
+    };
+    tokio::spawn(async move {
+        if let Err(e) =
+            run_compaction(compaction_config, compaction_manifest, compaction_shutdown).await
+        {
+            tracing::error!("compaction task exited with error: {e:#}");
         }
     });
 
@@ -1471,6 +1501,98 @@ mod tests {
         ).await;
         assert_eq!(rows2.len(), 1, "second query must return the same event from cache");
         assert_eq!(rows1[0]["kafka_offset"], rows2[0]["kafka_offset"]);
+    }
+
+    /// Compact 3 small, out-of-order, duplicate-containing files into a single
+    /// sorted, deduplicated output; assert the manifest reflects the swap atomically.
+    #[tokio::test]
+    async fn compaction_sorts_deduplicates_and_swaps_manifest() {
+        use crate::compact::{compact_bucket, CompactionConfig};
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("manifest.db");
+        let data_dir = dir.path().join("data");
+        let mut manifest = Manifest::open(&db_path).unwrap();
+
+        let make = |ts: i64, offset: i64| LogEvent {
+            timestamp: ts,
+            level: Level::Info,
+            service: "svc".to_string(),
+            message: "msg".to_string(),
+            kafka_partition: 0,
+            kafka_offset: offset,
+            attributes: HashMap::new(),
+        };
+
+        // File 1: ts=3000 (out of order), unique offset=3.
+        flush_events(&[make(3_000, 3)], &data_dir, &mut manifest).unwrap();
+        // File 2: ts=1000, offset=1.
+        flush_events(&[make(1_000, 1)], &data_dir, &mut manifest).unwrap();
+        // File 3: ts=1000 offset=1 (duplicate of file 2) + ts=2000 offset=2.
+        flush_events(&[make(1_000, 1), make(2_000, 2)], &data_dir, &mut manifest).unwrap();
+
+        assert_eq!(manifest.active_files(None).unwrap().len(), 3);
+
+        // Determine the time_bucket so compact_bucket can find the right files.
+        // All events have ts in the nanosecond range → 1970-01-01-00.
+        let buckets = manifest.compactable_buckets(2).unwrap();
+        assert_eq!(buckets.len(), 1);
+        let (service, time_bucket) = &buckets[0];
+
+        let manifest_arc = Arc::new(Mutex::new(manifest));
+        let config = CompactionConfig {
+            data_dir: data_dir.clone(),
+            min_files_per_bucket: 2,
+            target_file_bytes: 64 * 1024 * 1024,
+            interval_secs: 3600,
+        };
+
+        compact_bucket(service, time_bucket, &config, &manifest_arc)
+            .await
+            .unwrap();
+
+        let active = manifest_arc.lock().await.active_files(None).unwrap();
+
+        // Old 3 files superseded → 1 new compacted file active.
+        assert_eq!(active.len(), 1, "exactly one compacted file should be active");
+        assert_eq!(active[0].service, "svc");
+        assert_eq!(active[0].tier, "hot");
+        assert_eq!(active[0].record_count, 3, "3 unique events after dedup");
+
+        // Read the compacted output file directly with DataFusion to verify content.
+        let ctx = datafusion::prelude::SessionContext::new();
+        ctx.register_parquet("out", &active[0].path, ParquetReadOptions::default())
+            .await
+            .unwrap();
+        let batches = ctx
+            .sql("SELECT timestamp, kafka_offset FROM out ORDER BY timestamp")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let ts_col = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+        let off_col = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 3, "3 unique rows after dedup");
+
+        // Verify ascending timestamp sort.
+        assert!(ts_col.value(0) <= ts_col.value(1) && ts_col.value(1) <= ts_col.value(2),
+            "rows must be sorted by timestamp");
+
+        // Verify deduplication: no two rows share (partition, offset).
+        let offsets: Vec<i64> = (0..off_col.len()).map(|i| off_col.value(i)).collect();
+        let unique: std::collections::HashSet<i64> = offsets.iter().cloned().collect();
+        assert_eq!(unique.len(), offsets.len(), "no duplicate offsets");
     }
 
     /// Verify that buffer backpressure pauses and resumes the Kafka consumer without

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1595,6 +1595,66 @@ mod tests {
         assert_eq!(unique.len(), offsets.len(), "no duplicate offsets");
     }
 
+    /// Compacted Parquet files must carry row-group statistics on the timestamp column so
+    /// DataFusion can prune row groups at query time without reading page data.
+    #[tokio::test]
+    async fn compacted_file_has_row_group_statistics() {
+        use crate::compact::{compact_bucket, CompactionConfig};
+        use parquet::file::reader::{FileReader, SerializedFileReader};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("manifest.db");
+        let data_dir = dir.path().join("data");
+        let mut manifest = Manifest::open(&db_path).unwrap();
+
+        let make = |ts: i64, offset: i64| LogEvent {
+            timestamp: ts,
+            level: Level::Info,
+            service: "svc".to_string(),
+            message: "msg".to_string(),
+            kafka_partition: 0,
+            kafka_offset: offset,
+            attributes: HashMap::new(),
+        };
+
+        flush_events(&[make(1_000, 1)], &data_dir, &mut manifest).unwrap();
+        flush_events(&[make(2_000, 2)], &data_dir, &mut manifest).unwrap();
+
+        let buckets = manifest.compactable_buckets(2).unwrap();
+        assert_eq!(buckets.len(), 1);
+        let (service, time_bucket) = &buckets[0];
+
+        let manifest_arc = Arc::new(Mutex::new(manifest));
+        let config = CompactionConfig {
+            data_dir: data_dir.clone(),
+            min_files_per_bucket: 2,
+            target_file_bytes: 64 * 1024 * 1024,
+            interval_secs: 3600,
+        };
+        compact_bucket(service, time_bucket, &config, &manifest_arc)
+            .await
+            .unwrap();
+
+        let active = manifest_arc.lock().await.active_files(None).unwrap();
+        assert_eq!(active.len(), 1, "one compacted file expected");
+
+        let file = std::fs::File::open(&active[0].path).unwrap();
+        let reader = SerializedFileReader::new(file).unwrap();
+        let metadata = reader.metadata();
+        assert!(metadata.num_row_groups() > 0);
+
+        let file_schema = metadata.file_metadata().schema_descr();
+        let ts_col_idx = (0..file_schema.num_columns())
+            .find(|&i| file_schema.column(i).name() == "timestamp")
+            .expect("timestamp column must exist in compacted file");
+
+        let rg = metadata.row_group(0);
+        assert!(
+            rg.column(ts_col_idx).statistics().is_some(),
+            "timestamp column must carry row-group statistics for min/max pruning"
+        );
+    }
+
     /// Verify that buffer backpressure pauses and resumes the Kafka consumer without
     /// dropping events. Uses a tiny batch buffer (500 bytes) so that two events
     /// (~240 bytes each) push occupancy above the 0.8 high-water mark, triggering


### PR DESCRIPTION
## Summary

**Manifest additions** (`crates/manifest`):
- `compactable_buckets(min_files)` — GROUP BY `(service, time_bucket)`, returns pairs with ≥ N hot active files
- `active_hot_files_for_bucket(service, time_bucket)` — all hot active files for one partition  
- `swap_compacted(old_ids, new_files)` — single SQLite transaction: inserts new files as `active`, marks old IDs `superseded`; no window where data is absent or duplicated

**`server/src/compact.rs`** (new):
- `CompactionConfig`: `data_dir`, `min_files_per_bucket` (default 2), `target_file_bytes` (default 64 MiB IPC proxy), `interval_secs` (default 1800)
- `run_compaction`: background Tokio task, same shutdown-biased select pattern as tiering/consumer
- `compact_bucket` (public): reads hot files → DataFusion `ROW_NUMBER() OVER (PARTITION BY kafka_partition, kafka_offset ORDER BY timestamp)` for sort+dedup in one pass (same logic as query-time dedup, now applied permanently) → split output by IPC size → write Parquet → `swap_compacted` → best-effort delete superseded local files
- Queries in flight during compaction continue reading the old active files; they see the new compacted file only after the atomic swap commits

Wired in `main()` via `COMPACT_MIN_FILES`, `COMPACT_TARGET_BYTES`, `COMPACT_INTERVAL_SECS` env vars.

## Test plan

- [x] Unit test passes without external services: `cargo test -p server compaction`
- [x] All non-ignored tests pass: `cargo test -p server`

The unit test: 3 files with out-of-order timestamps and a duplicate `kafka_offset=1` → `compact_bucket` → asserts 1 active file, 3 unique rows sorted ascending by `timestamp`, no duplicate offsets, all 3 old files superseded.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)