### PR TITLE
feat(#20): retention sweeper — TTL enforcement + superseded file cleanup

### DIFF
--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 anyhow = { workspace = true }
 serde = { workspace = true }
 rusqlite = { version = "0.32", features = ["bundled"] }
+
+[dev-dependencies]
+tempfile = "3"
+uuid = { version = "1", features = ["v4"] }

--- a/crates/manifest/src/lib.rs
+++ b/crates/manifest/src/lib.rs
@@ -70,12 +70,20 @@ impl Manifest {
                 record_count      INTEGER NOT NULL,
                 state             TEXT NOT NULL DEFAULT 'active',
                 min_kafka_offset  INTEGER NOT NULL,
-                max_kafka_offset  INTEGER NOT NULL
+                max_kafka_offset  INTEGER NOT NULL,
+                superseded_at     INTEGER NOT NULL DEFAULT 0
             );
             CREATE INDEX IF NOT EXISTS idx_files_covering
                 ON files (service, time_bucket, min_ts, max_ts);",
         )
         .context("create schema")?;
+
+        // Migrate existing databases that pre-date the superseded_at column.
+        // ALTER TABLE ADD COLUMN fails with "duplicate column name" if the column
+        // already exists — that error is intentionally ignored.
+        let _ = conn.execute_batch(
+            "ALTER TABLE files ADD COLUMN superseded_at INTEGER NOT NULL DEFAULT 0;",
+        );
 
         Ok(Manifest { conn })
     }
@@ -228,7 +236,7 @@ impl Manifest {
         }
         for &id in old_ids {
             tx.execute(
-                "UPDATE files SET state = 'superseded' WHERE id = ?1",
+                "UPDATE files SET state = 'superseded', superseded_at = unixepoch() WHERE id = ?1",
                 params![id],
             )
             .context("mark file superseded")?;
@@ -314,6 +322,66 @@ impl Manifest {
             .context("query active_files")?;
         rows.collect::<std::result::Result<_, _>>().context("collect rows")
     }
+
+    /// Return active files older than the given retention cutoffs (nanosecond timestamps).
+    /// Hot and cold tiers may have different retention windows.
+    pub fn expired_active_files(
+        &self,
+        hot_cutoff_ns: i64,
+        cold_cutoff_ns: i64,
+    ) -> Result<Vec<FileEntry>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, path, tier, service, time_bucket, min_ts, max_ts,
+                        size_bytes, record_count, state, min_kafka_offset, max_kafka_offset
+                 FROM files
+                 WHERE state = 'active'
+                   AND ((tier = 'hot'  AND max_ts < ?1)
+                     OR (tier = 'cold' AND max_ts < ?2))",
+            )
+            .context("prepare expired_active_files")?;
+        let rows = stmt
+            .query_map(params![hot_cutoff_ns, cold_cutoff_ns], map_row)
+            .context("query expired_active_files")?
+            .collect::<std::result::Result<_, _>>()
+            .context("collect rows")?;
+        Ok(rows)
+    }
+
+    /// Return superseded files whose superseded_at timestamp is before `grace_cutoff_unix_secs`.
+    /// Files with superseded_at = 0 (pre-migration) are excluded to avoid mass-deleting
+    /// files that were superseded before the column existed.
+    pub fn superseded_files_past_grace(
+        &self,
+        grace_cutoff_unix_secs: i64,
+    ) -> Result<Vec<FileEntry>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, path, tier, service, time_bucket, min_ts, max_ts,
+                        size_bytes, record_count, state, min_kafka_offset, max_kafka_offset
+                 FROM files
+                 WHERE state = 'superseded'
+                   AND superseded_at > 0
+                   AND superseded_at < ?1",
+            )
+            .context("prepare superseded_files_past_grace")?;
+        let rows = stmt
+            .query_map(params![grace_cutoff_unix_secs], map_row)
+            .context("query superseded_files_past_grace")?
+            .collect::<std::result::Result<_, _>>()
+            .context("collect rows")?;
+        Ok(rows)
+    }
+
+    /// Remove a file entry from the manifest by id.
+    pub fn delete_file(&mut self, id: i64) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM files WHERE id = ?1", params![id])
+            .context("delete_file")?;
+        Ok(())
+    }
 }
 
 fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<FileEntry> {
@@ -331,4 +399,68 @@ fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<FileEntry> {
         min_kafka_offset: row.get(10)?,
         max_kafka_offset: row.get(11)?,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn insert_file(m: &mut Manifest, state: &str, max_ts: i64, superseded_at: i64) -> i64 {
+        m.conn.execute(
+            "INSERT INTO files
+                (path, tier, service, time_bucket, min_ts, max_ts,
+                 size_bytes, record_count, state, min_kafka_offset, max_kafka_offset, superseded_at)
+             VALUES (?, 'hot', 'svc', '2024-01-01-00', 0, ?, 0, 0, ?, 0, 0, ?)",
+            rusqlite::params![
+                format!("/tmp/fake-{}.parquet", uuid::Uuid::new_v4()),
+                max_ts, state, superseded_at
+            ],
+        ).unwrap();
+        m.conn.last_insert_rowid()
+    }
+
+    #[test]
+    fn expired_active_files_returns_only_expired() {
+        let dir = tempdir().unwrap();
+        let mut m = Manifest::open(&dir.path().join("m.db")).unwrap();
+
+        let old_id = insert_file(&mut m, "active", 1_000, 0);       // ancient
+        let _new_id = insert_file(&mut m, "active", i64::MAX, 0);    // far future
+
+        let expired = m.expired_active_files(1_000_000_000, i64::MAX).unwrap();
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].id, old_id);
+    }
+
+    #[test]
+    fn superseded_files_past_grace_excludes_recent_and_legacy() {
+        let dir = tempdir().unwrap();
+        let mut m = Manifest::open(&dir.path().join("m.db")).unwrap();
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs() as i64;
+
+        let old_id = insert_file(&mut m, "superseded", 0, now - 3600); // 1h ago
+        let _recent = insert_file(&mut m, "superseded", 0, now);        // just now
+        let _legacy = insert_file(&mut m, "superseded", 0, 0);          // pre-migration default
+
+        let grace_cutoff = now - 600; // 10-minute grace
+        let eligible = m.superseded_files_past_grace(grace_cutoff).unwrap();
+        assert_eq!(eligible.len(), 1);
+        assert_eq!(eligible[0].id, old_id);
+    }
+
+    #[test]
+    fn delete_file_removes_row() {
+        let dir = tempdir().unwrap();
+        let mut m = Manifest::open(&dir.path().join("m.db")).unwrap();
+        let id = insert_file(&mut m, "active", 1000, 0);
+        m.delete_file(id).unwrap();
+        let count: i64 = m.conn
+            .query_row("SELECT COUNT(*) FROM files WHERE id = ?1", rusqlite::params![id], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,9 +1,11 @@
 pub use compact::{compact_bucket, run_compaction, CompactionConfig};
 pub use consumer::{run_consumer, ConsumerConfig};
 pub use flush::flush_events;
+pub use sweeper::{run_sweeper, SweeperConfig};
 pub use tier::{run_tiering, TieringConfig};
 
 pub mod compact;
 mod consumer;
 mod flush;
+pub mod sweeper;
 pub mod tier;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -21,7 +21,7 @@ use manifest::Manifest;
 use serde::Deserialize;
 use cold_cache::ColdCache;
 use compact::{run_compaction, CompactionConfig};
-use server::{run_consumer, run_tiering, ConsumerConfig, TieringConfig};
+use server::{run_consumer, run_sweeper, run_tiering, ConsumerConfig, SweeperConfig, TieringConfig};
 use storage::MinioConfig;
 
 mod assets;
@@ -385,6 +385,38 @@ async fn main() {
         .await
         {
             tracing::error!("compaction task exited with error: {e:#}");
+        }
+    });
+
+    // Start background retention sweeper.
+    let sweeper_manifest = Arc::clone(&manifest);
+    let sweeper_minio = minio_config.clone();
+    let sweeper_shutdown = shutdown_tx.subscribe();
+    let sweeper_config = SweeperConfig {
+        hot_retention_secs: std::env::var("HOT_RETENTION_DAYS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(14)
+            * 86_400,
+        cold_retention_secs: std::env::var("COLD_RETENTION_DAYS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(90)
+            * 86_400,
+        superseded_grace_secs: std::env::var("SUPERSEDED_GRACE_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(600),
+        interval_secs: std::env::var("SWEEP_INTERVAL_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(300),
+    };
+    tokio::spawn(async move {
+        if let Err(e) =
+            run_sweeper(sweeper_config, sweeper_manifest, sweeper_minio, sweeper_shutdown).await
+        {
+            tracing::error!("sweeper task exited with error: {e:#}");
         }
     });
 
@@ -1738,6 +1770,66 @@ mod tests {
             "threshold trigger should have compacted 5 small files; still {} active",
             active.len()
         );
+    }
+
+    #[tokio::test]
+    async fn sweeper_removes_expired_hot_files() {
+        use server::{run_sweeper, SweeperConfig};
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("manifest.db");
+        let data_dir = dir.path().join("data");
+        let mut manifest = Manifest::open(&db_path).unwrap();
+
+        // Flush a file whose timestamp is ancient (1 000 ns — epoch + 1 µs).
+        let ancient_ts: i64 = 1_000;
+        let expired_event = LogEvent {
+            timestamp: ancient_ts,
+            level: Level::Info,
+            service: "svc".to_string(),
+            message: "ancient event".to_string(),
+            kafka_partition: 0,
+            kafka_offset: 0,
+            attributes: HashMap::new(),
+        };
+        flush_events(&[expired_event], &data_dir, &mut manifest).unwrap();
+
+        let files = manifest.active_files(None).unwrap();
+        assert_eq!(files.len(), 1);
+        let expired_path = files[0].path.clone();
+        assert!(std::path::Path::new(&expired_path).exists(), "file should be on disk before sweep");
+
+        let manifest_arc = Arc::new(Mutex::new(manifest));
+        let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel::<()>(1);
+        let sweeper_manifest = Arc::clone(&manifest_arc);
+
+        tokio::spawn(async move {
+            let _ = run_sweeper(
+                SweeperConfig {
+                    // 1-second retention so the ancient file is immediately eligible.
+                    hot_retention_secs: 1,
+                    cold_retention_secs: 1,
+                    superseded_grace_secs: 600,
+                    interval_secs: 1,
+                },
+                sweeper_manifest,
+                MinioConfig::default(),
+                shutdown_rx,
+            )
+            .await;
+        });
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let _ = shutdown_tx.send(());
+
+        // File must be gone from disk.
+        assert!(
+            !std::path::Path::new(&expired_path).exists(),
+            "expired file should be deleted from disk by sweeper"
+        );
+        // File must be gone from manifest.
+        let remaining = manifest_arc.lock().await.active_files(None).unwrap();
+        assert_eq!(remaining.len(), 0, "expired file should be removed from manifest by sweeper");
     }
 
     /// Verify that buffer backpressure pauses and resumes the Kafka consumer without

--- a/server/src/sweeper.rs
+++ b/server/src/sweeper.rs
@@ -1,0 +1,179 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use manifest::Manifest;
+use storage::{minio_store, MinioConfig};
+use tokio::sync::{broadcast, Mutex};
+
+pub struct SweeperConfig {
+    /// Retention window for hot-tier files in seconds. Default: 14 days.
+    pub hot_retention_secs: u64,
+    /// Retention window for cold-tier files in seconds. Default: 90 days.
+    pub cold_retention_secs: u64,
+    /// Grace period before superseded files are deleted in seconds. Default: 10 minutes.
+    pub superseded_grace_secs: u64,
+    /// How often the sweeper runs in seconds. Default: 5 minutes.
+    pub interval_secs: u64,
+}
+
+impl Default for SweeperConfig {
+    fn default() -> Self {
+        Self {
+            hot_retention_secs: 14 * 86_400,
+            cold_retention_secs: 90 * 86_400,
+            superseded_grace_secs: 600,
+            interval_secs: 300,
+        }
+    }
+}
+
+pub async fn run_sweeper(
+    config: SweeperConfig,
+    manifest: Arc<Mutex<Manifest>>,
+    minio: MinioConfig,
+    mut shutdown: broadcast::Receiver<()>,
+) -> Result<()> {
+    let mut tick = tokio::time::interval(Duration::from_secs(config.interval_secs));
+    tick.tick().await; // skip the immediate first tick
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.recv() => return Ok(()),
+            _ = tick.tick() => {}
+        }
+
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        let now_ns = now_secs * 1_000_000_000;
+        let hot_cutoff_ns = now_ns - config.hot_retention_secs as i64 * 1_000_000_000;
+        let cold_cutoff_ns = now_ns - config.cold_retention_secs as i64 * 1_000_000_000;
+        let grace_cutoff_secs = now_secs - config.superseded_grace_secs as i64;
+
+        sweep_expired(&manifest, &minio, hot_cutoff_ns, cold_cutoff_ns).await;
+        sweep_superseded(&manifest, grace_cutoff_secs).await;
+    }
+}
+
+async fn sweep_expired(
+    manifest: &Arc<Mutex<Manifest>>,
+    minio: &MinioConfig,
+    hot_cutoff_ns: i64,
+    cold_cutoff_ns: i64,
+) {
+    let files = {
+        match manifest.lock().await.expired_active_files(hot_cutoff_ns, cold_cutoff_ns) {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::warn!("sweeper: failed to query expired files: {e:#}");
+                return;
+            }
+        }
+    };
+
+    if files.is_empty() {
+        return;
+    }
+
+    // Build the MinIO store once, lazily, only if cold files need deletion.
+    let cold_store = if files.iter().any(|f| f.tier == "cold") {
+        match minio_store(minio) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                tracing::warn!("sweeper: cannot build MinIO store for cold deletion: {e:#}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    for file in files {
+        // Delete the physical file first; only remove the manifest row on success
+        // so a crash between the two doesn't orphan the manifest entry while the
+        // file is still readable.
+        let deleted = if file.tier == "cold" {
+            delete_cold(&file.path, minio, cold_store.as_deref()).await
+        } else {
+            delete_local(&file.path).await
+        };
+
+        if !deleted {
+            continue;
+        }
+
+        if let Err(e) = manifest.lock().await.delete_file(file.id) {
+            tracing::warn!(id = file.id, path = %file.path, "sweeper: failed to remove expired file from manifest: {e:#}");
+        } else {
+            tracing::info!(
+                id = file.id, tier = %file.tier, path = %file.path,
+                "sweeper: deleted expired file"
+            );
+        }
+    }
+}
+
+async fn sweep_superseded(manifest: &Arc<Mutex<Manifest>>, grace_cutoff_secs: i64) {
+    let files = {
+        match manifest.lock().await.superseded_files_past_grace(grace_cutoff_secs) {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::warn!("sweeper: failed to query superseded files: {e:#}");
+                return;
+            }
+        }
+    };
+
+    for file in files {
+        // Superseded files are hot-tier only (compaction never touches cold files),
+        // so we always delete locally.
+        let deleted = delete_local(&file.path).await;
+
+        // For superseded files the manifest row is the source of truth; even if
+        // the physical file is already gone we still clean up the row.
+        if let Err(e) = manifest.lock().await.delete_file(file.id) {
+            tracing::warn!(id = file.id, "sweeper: failed to remove superseded file from manifest: {e:#}");
+        } else if deleted {
+            tracing::info!(id = file.id, path = %file.path, "sweeper: deleted superseded file");
+        } else {
+            tracing::info!(id = file.id, path = %file.path, "sweeper: removed already-missing superseded file from manifest");
+        }
+    }
+}
+
+async fn delete_local(path: &str) -> bool {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(e) => {
+            tracing::warn!(path, "sweeper: failed to delete local file: {e}");
+            false
+        }
+    }
+}
+
+async fn delete_cold(
+    cold_uri: &str,
+    minio: &MinioConfig,
+    store: Option<&dyn storage::object_store::ObjectStore>,
+) -> bool {
+    // cold_uri format: "s3://{bucket}/{key}"
+    let key = cold_uri
+        .strip_prefix(&format!("s3://{}/", minio.bucket))
+        .unwrap_or(cold_uri);
+
+    let Some(store) = store else { return false };
+    use storage::object_store::ObjectStore as _;
+    match store.delete(&storage::object_store::path::Path::from(key)).await {
+        Ok(()) => true,
+        Err(storage::object_store::Error::NotFound { .. }) => true,
+        Err(e) => {
+            tracing::warn!(uri = cold_uri, "sweeper: failed to delete cold file: {e}");
+            false
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `run_sweeper` background task enforces data retention and cleans compaction debris
- Deletes active hot/cold files whose `max_ts` exceeds the configured window (14-day hot, 90-day cold default); cold files are removed from MinIO via the `object_store` delete API
- Deletes superseded files past the grace period (default 10 min) left behind by compaction
- Deletion order: physical file first, then manifest row — a crash between the two leaves the manifest entry intact so the next sweep retries cleanly

## Manifest changes

- `superseded_at INTEGER DEFAULT 0` column added via `ALTER TABLE` migration (no-op on new DBs, safe on existing ones)
- `swap_compacted` now stamps `superseded_at = unixepoch()` on each superseded row
- New public methods: `expired_active_files`, `superseded_files_past_grace`, `delete_file`

## Env vars

| Var | Default | Meaning |
|---|---|---|
| `HOT_RETENTION_DAYS` | 14 | Retention window for hot-tier files |
| `COLD_RETENTION_DAYS` | 90 | Retention window for cold-tier files |
| `SUPERSEDED_GRACE_SECS` | 600 | Grace period before superseded files are deleted |
| `SWEEP_INTERVAL_SECS` | 300 | How often the sweeper runs |

## Test plan

- [x] `cargo test -p server -p manifest -- --skip ignored` — 14 tests pass
- [x] 3 new manifest unit tests: `expired_active_files_returns_only_expired`, `superseded_files_past_grace_excludes_recent_and_legacy`, `delete_file_removes_row`
- [x] Integration test `sweeper_removes_expired_hot_files`: flushes a file with `max_ts = 1000 ns`, runs sweeper with 1-second retention, asserts file gone from disk and manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)