### PR TITLE
feat(#26): observability — /metrics, /health, /ready, Grafana dashboard

### DIFF
--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: log-ingest
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/grafana/provisioning/dashboards/log-ingest.json
+++ b/grafana/provisioning/dashboards/log-ingest.json
@@ -1,0 +1,170 @@
+{
+  "title": "log-ingest",
+  "uid": "log-ingest",
+  "schemaVersion": 36,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Ingest Rate (events/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (service) (rate(events_ingested_total[1m]))",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Kafka Consumer Lag",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "kafka_consumer_lag",
+          "legendFormat": "partition {{partition}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Flush Latency p99 (s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, rate(flush_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, rate(flush_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Query Duration p99 (s)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, rate(query_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, rate(query_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Active Queries",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 16, "w": 4, "h": 4 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "active_queries",
+          "legendFormat": "active"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Files Active by Tier",
+      "type": "timeseries",
+      "gridPos": { "x": 4, "y": 16, "w": 10, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "files_active",
+          "legendFormat": "{{tier}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Cold Cache Hit Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 14, "y": 16, "w": 10, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(cache_hits_total[5m]) / (rate(cache_hits_total[5m]) + rate(cache_misses_total[5m]))",
+          "legendFormat": "hit rate"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Rate Limit Rejections (req/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 24, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(rate_limit_rejected_total[1m])",
+          "legendFormat": "rejected/s"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Bytes Scanned (bytes/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": { "unit": "Bps" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(bytes_scanned_total[1m])",
+          "legendFormat": "bytes/s"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Backpressure Pauses (pauses/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(backpressure_pauses_total[1m])",
+          "legendFormat": "partition {{partition}}"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "Buffer Occupancy",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 },
+      "fieldConfig": {
+        "defaults": { "min": 0, "max": 1, "unit": "percentunit" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "buffer_occupancy_ratio",
+          "legendFormat": "partition {{partition}}"
+        }
+      ]
+    }
+  ]
+}

--- a/server/src/consumer.rs
+++ b/server/src/consumer.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -176,6 +176,7 @@ pub async fn run_consumer(
     manifest: Arc<Mutex<Manifest>>,
     backpressure_pauses: Arc<AtomicU64>,
     flush_semaphore: Arc<Semaphore>,
+    consumer_ready: Arc<AtomicBool>,
     mut shutdown: broadcast::Receiver<()>,
 ) -> Result<()> {
     let (flush_tx, mut flush_rx) = mpsc::unbounded_channel::<FlushResult>();
@@ -200,6 +201,7 @@ pub async fn run_consumer(
         .create_with_context(ctx)?;
 
     consumer.subscribe(&[&config.topic])?;
+    consumer_ready.store(true, Ordering::Release);
     tracing::info!("consumer subscribed to topic '{}'", config.topic);
 
     let mut tick = interval(Duration::from_millis(100));
@@ -218,7 +220,7 @@ pub async fn run_consumer(
                                 event.kafka_partition = partition;
                                 event.kafka_offset = m.offset();
 
-                                let (batch, up_to_offset, pause_semaphore, pause_highwater) = {
+                                let (batch, up_to_offset, pause_semaphore, pause_highwater, occupancy) = {
                                     let mut s = store.lock().unwrap();
                                     s.pending.insert(partition, m.offset() + 1);
 
@@ -236,20 +238,25 @@ pub async fn run_consumer(
 
                                     let up_to_offset = s.pending[&partition];
                                     let is_paused = s.paused.contains(&partition);
+                                    let occ = s.buffers[&partition].occupancy();
 
                                     if batch.is_some() {
                                         // Flush triggered — pause if semaphore saturated.
                                         let sem = flush_semaphore.available_permits() == 0 && !is_paused;
                                         if sem { s.paused.insert(partition); }
-                                        (batch, up_to_offset, sem, false)
+                                        (batch, up_to_offset, sem, false, occ)
                                     } else {
                                         // No flush — check high-water mark.
-                                        let occ = s.buffers[&partition].occupancy();
                                         let hwm = !is_paused && occ > HIGH_WATER_MARK;
                                         if hwm { s.paused.insert(partition); }
-                                        (None, up_to_offset, false, hwm)
+                                        (None, up_to_offset, false, hwm, occ)
                                     }
                                 };
+
+                                metrics::gauge!(
+                                    "buffer_occupancy_ratio",
+                                    "partition" => partition.to_string()
+                                ).set(occupancy as f64);
 
                                 if pause_semaphore || pause_highwater {
                                     pause_partition(
@@ -312,6 +319,20 @@ pub async fn run_consumer(
                 // Age-triggered flush: check every partition buffer independently.
                 let partitions: Vec<i32> =
                     store.lock().unwrap().buffers.keys().copied().collect();
+                // Emit consumer lag per partition (high watermark - last committed offset).
+                for partition in &partitions {
+                    if let Ok((_, high)) = consumer.fetch_watermarks(
+                        &config.topic,
+                        *partition,
+                        Duration::from_millis(10),
+                    ) {
+                        let committed = store.lock().unwrap().committed.get(partition).copied().unwrap_or(0);
+                        metrics::gauge!(
+                            "kafka_consumer_lag",
+                            "partition" => partition.to_string()
+                        ).set((high - committed).max(0) as f64);
+                    }
+                }
                 for partition in partitions {
                     let batch_info = {
                         let mut s = store.lock().unwrap();
@@ -486,6 +507,10 @@ fn pause_partition<C: ConsumerContext>(
         tracing::error!("failed to pause partition {partition}: {e}");
     } else {
         let count = pauses_total.fetch_add(1, Ordering::Relaxed) + 1;
+        metrics::counter!(
+            "backpressure_pauses_total",
+            "partition" => partition.to_string()
+        ).increment(1);
         tracing::info!(
             "backpressure: paused partition {partition} (total pauses: {count})"
         );

--- a/server/src/consumer.rs
+++ b/server/src/consumer.rs
@@ -201,8 +201,15 @@ pub async fn run_consumer(
         .create_with_context(ctx)?;
 
     consumer.subscribe(&[&config.topic])?;
-    consumer_ready.store(true, Ordering::Release);
-    tracing::info!("consumer subscribed to topic '{}'", config.topic);
+    // fetch_metadata actually connects to the broker; subscribe() alone is local-only.
+    // Only signal ready after confirming the broker is reachable.
+    match consumer.client().fetch_metadata(None, Duration::from_secs(10)) {
+        Ok(_) => {
+            consumer_ready.store(true, Ordering::Release);
+            tracing::info!("consumer subscribed to topic '{}' — broker reachable", config.topic);
+        }
+        Err(e) => tracing::warn!("consumer subscribed but broker not yet reachable: {e}"),
+    }
 
     let mut tick = interval(Duration::from_millis(100));
 

--- a/server/src/flush.rs
+++ b/server/src/flush.rs
@@ -48,5 +48,12 @@ pub fn flush_events(events: &[LogEvent], data_dir: &Path, manifest: &mut Manifes
         })
         .context("commit flush")?;
 
+    metrics::counter!(
+        "events_ingested_total",
+        "service" => service.clone(),
+        "partition" => events[0].kafka_partition.to_string()
+    )
+    .increment(events.len() as u64);
+
     Ok(file_path)
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -86,6 +86,19 @@ struct AppState {
     job_timeout_secs: u64,
     job_semaphore: Arc<Semaphore>,
     per_client_queue_cap: usize,
+    consumer_ready: Arc<AtomicBool>,
+}
+
+async fn health_handler() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+async fn ready_handler(State(state): State<AppState>) -> impl IntoResponse {
+    if state.consumer_ready.load(std::sync::atomic::Ordering::Acquire) {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
 }
 
 async fn query_handler(
@@ -213,6 +226,9 @@ async fn stream_query(
         .await
         .context("execute query")?;
 
+    metrics::gauge!("active_queries").increment(1.0);
+    metrics::counter!("bytes_scanned_total").increment(bytes_scanned);
+
     let (tx, rx) = mpsc::unbounded::<Result<Bytes, BoxError>>();
     let started_at = std::time::Instant::now();
 
@@ -225,6 +241,7 @@ async fn stream_query(
         while let Some(result) = stream.next().await {
             match result {
                 Err(e) => {
+                    metrics::gauge!("active_queries").decrement(1.0);
                     tx.unbounded_send(Err(Box::new(e) as BoxError)).ok();
                     return;
                 }
@@ -252,12 +269,14 @@ async fn stream_query(
             }
         }
 
-        let duration_ms = started_at.elapsed().as_millis() as u64;
+        let elapsed = started_at.elapsed();
+        metrics::histogram!("query_duration_seconds").record(elapsed.as_secs_f64());
+        metrics::gauge!("active_queries").decrement(1.0);
         tx.unbounded_send(Ok(make_stats_bytes(
             rows_scanned,
             files_pruned,
             bytes_scanned,
-            duration_ms,
+            elapsed.as_millis() as u64,
         )))
         .ok();
     });
@@ -355,6 +374,7 @@ async fn submit_job_handler(
             .filter(|e| matches!(e.state, JobState::Queued) && e.client_ip == client_ip)
             .count();
         if queued >= state.per_client_queue_cap {
+            metrics::counter!("rate_limit_rejected_total").increment(1);
             return (
                 StatusCode::TOO_MANY_REQUESTS,
                 [(header::RETRY_AFTER, "5")],
@@ -651,10 +671,12 @@ async fn main() {
     let flush_semaphore = Arc::new(Semaphore::new(max_concurrent_flushes));
 
     // Start Kafka consumer as a background task.
+    let consumer_ready = Arc::new(AtomicBool::new(false));
     let consumer_manifest = Arc::clone(&manifest);
     let consumer_semaphore = Arc::clone(&flush_semaphore);
     let consumer_shutdown = shutdown_tx.subscribe();
     let consumer_data_dir = data_dir.clone();
+    let consumer_ready_bg = Arc::clone(&consumer_ready);
     tokio::spawn(async move {
         if let Err(e) = run_consumer(
             ConsumerConfig::default(),
@@ -662,6 +684,7 @@ async fn main() {
             consumer_manifest,
             Arc::new(AtomicU64::new(0)),
             consumer_semaphore,
+            consumer_ready_bg,
             consumer_shutdown,
         )
         .await
@@ -821,6 +844,7 @@ async fn main() {
         job_timeout_secs,
         job_semaphore: Arc::new(Semaphore::new(max_concurrent_jobs)),
         per_client_queue_cap,
+        consumer_ready,
     };
     let app = Router::new()
         .route("/ingest", post(ingest_handler))
@@ -828,7 +852,8 @@ async fn main() {
         .route("/jobs", post(submit_job_handler))
         .route("/jobs/:id", get(poll_job_handler).delete(delete_job_handler))
         .route("/jobs/:id/results", get(results_job_handler))
-        .route("/health", axum::routing::get(|| async { "ok" }))
+        .route("/health", axum::routing::get(health_handler))
+        .route("/ready", axum::routing::get(ready_handler))
         .route("/metrics", axum::routing::get({
             let handle = prometheus_handle.clone();
             move || { let h = handle.clone(); async move { h.render() } }
@@ -884,6 +909,7 @@ mod tests {
             job_timeout_secs: 300,
             job_semaphore: Arc::new(Semaphore::new(8)),
             per_client_queue_cap: 5,
+            consumer_ready: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -1379,6 +1405,7 @@ mod tests {
                 consumer_manifest,
                 Arc::new(AtomicU64::new(0)),
                 Arc::new(Semaphore::new(4)),
+                Arc::new(AtomicBool::new(false)),
                 shutdown_rx,
             )
             .await;
@@ -1390,7 +1417,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Query and assert all N events are present.
-        let state = AppState { manifest, minio: MinioConfig::default(), cold_semaphore: Arc::new(Semaphore::new(4)), cold_cache: Arc::new(Mutex::new(ColdCache::new(std::env::temp_dir().join("log-ingest-test-cache"), 10 * 1024 * 1024 * 1024).unwrap())), job_store: Arc::new(Mutex::new(HashMap::new())), jobs_dir: std::env::temp_dir().join("log-ingest-test-jobs"), job_timeout_secs: 300, job_semaphore: Arc::new(Semaphore::new(8)), per_client_queue_cap: 5 };
+        let state = AppState { manifest, minio: MinioConfig::default(), cold_semaphore: Arc::new(Semaphore::new(4)), cold_cache: Arc::new(Mutex::new(ColdCache::new(std::env::temp_dir().join("log-ingest-test-cache"), 10 * 1024 * 1024 * 1024).unwrap())), job_store: Arc::new(Mutex::new(HashMap::new())), jobs_dir: std::env::temp_dir().join("log-ingest-test-jobs"), job_timeout_secs: 300, job_semaphore: Arc::new(Semaphore::new(8)), per_client_queue_cap: 5, consumer_ready: Arc::new(AtomicBool::new(true)) };
         let rows = query_rows(state, QueryRequest {
             sql: "SELECT * FROM logs".to_string(),
             time_from: Some(0),
@@ -1447,7 +1474,7 @@ mod tests {
                 bootstrap_servers: "localhost:9092".to_string(),
                 group_id: gid, topic: top,
                 ..ConsumerConfig::default()
-            }, dd, m2, Arc::new(AtomicU64::new(0)), Arc::new(Semaphore::new(4)), rx).await;
+            }, dd, m2, Arc::new(AtomicU64::new(0)), Arc::new(Semaphore::new(4)), Arc::new(AtomicBool::new(false)), rx).await;
         });
         tokio::time::sleep(Duration::from_secs(3)).await;
         let _ = tx.send(());
@@ -1535,14 +1562,14 @@ mod tests {
                 bootstrap_servers: "localhost:9092".to_string(),
                 group_id: gid, topic: top,
                 ..ConsumerConfig::default()
-            }, dd, m2, Arc::new(AtomicU64::new(0)), Arc::new(Semaphore::new(4)), rx).await;
+            }, dd, m2, Arc::new(AtomicU64::new(0)), Arc::new(Semaphore::new(4)), Arc::new(AtomicBool::new(false)), rx).await;
         });
         tokio::time::sleep(Duration::from_secs(3)).await;
         let _ = tx.send(());
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // All N events must be present — none were permanently lost.
-        let state = AppState { manifest, minio: MinioConfig::default(), cold_semaphore: Arc::new(Semaphore::new(4)), cold_cache: Arc::new(Mutex::new(ColdCache::new(std::env::temp_dir().join("log-ingest-test-cache"), 10 * 1024 * 1024 * 1024).unwrap())), job_store: Arc::new(Mutex::new(HashMap::new())), jobs_dir: std::env::temp_dir().join("log-ingest-test-jobs"), job_timeout_secs: 300, job_semaphore: Arc::new(Semaphore::new(8)), per_client_queue_cap: 5 };
+        let state = AppState { manifest, minio: MinioConfig::default(), cold_semaphore: Arc::new(Semaphore::new(4)), cold_cache: Arc::new(Mutex::new(ColdCache::new(std::env::temp_dir().join("log-ingest-test-cache"), 10 * 1024 * 1024 * 1024).unwrap())), job_store: Arc::new(Mutex::new(HashMap::new())), jobs_dir: std::env::temp_dir().join("log-ingest-test-jobs"), job_timeout_secs: 300, job_semaphore: Arc::new(Semaphore::new(8)), per_client_queue_cap: 5, consumer_ready: Arc::new(AtomicBool::new(true)) };
         let rows = query_rows(state, QueryRequest {
             sql: "SELECT * FROM logs".to_string(),
             time_from: Some(0), time_to: Some(i64::MAX), limit: 1000,
@@ -1626,6 +1653,7 @@ mod tests {
                 m1,
                 Arc::new(AtomicU64::new(0)),
                 Arc::new(Semaphore::new(4)),
+                Arc::new(AtomicBool::new(false)),
                 rx1,
             )
             .await;
@@ -1654,6 +1682,7 @@ mod tests {
                 m2,
                 Arc::new(AtomicU64::new(0)),
                 Arc::new(Semaphore::new(4)),
+                Arc::new(AtomicBool::new(false)),
                 rx2,
             )
             .await;
@@ -1666,7 +1695,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // All N events must be present with no duplicates (unique by kafka_offset).
-        let state = AppState { manifest, minio: MinioConfig::default(), cold_semaphore: Arc::new(Semaphore::new(4)), cold_cache: Arc::new(Mutex::new(ColdCache::new(std::env::temp_dir().join("log-ingest-test-cache"), 10 * 1024 * 1024 * 1024).unwrap())), job_store: Arc::new(Mutex::new(HashMap::new())), jobs_dir: std::env::temp_dir().join("log-ingest-test-jobs"), job_timeout_secs: 300, job_semaphore: Arc::new(Semaphore::new(8)), per_client_queue_cap: 5 };
+        let state = AppState { manifest, minio: MinioConfig::default(), cold_semaphore: Arc::new(Semaphore::new(4)), cold_cache: Arc::new(Mutex::new(ColdCache::new(std::env::temp_dir().join("log-ingest-test-cache"), 10 * 1024 * 1024 * 1024).unwrap())), job_store: Arc::new(Mutex::new(HashMap::new())), jobs_dir: std::env::temp_dir().join("log-ingest-test-jobs"), job_timeout_secs: 300, job_semaphore: Arc::new(Semaphore::new(8)), per_client_queue_cap: 5, consumer_ready: Arc::new(AtomicBool::new(true)) };
         let rows = query_rows(
             state,
             QueryRequest {
@@ -1843,6 +1872,7 @@ mod tests {
             job_timeout_secs: 300,
             job_semaphore: Arc::new(Semaphore::new(8)),
             per_client_queue_cap: 5,
+            consumer_ready: Arc::new(AtomicBool::new(true)),
         };
         let (rows, _stats) = query(
             state,
@@ -1923,6 +1953,7 @@ mod tests {
             job_timeout_secs: 300,
             job_semaphore: Arc::new(Semaphore::new(8)),
             per_client_queue_cap: 5,
+            consumer_ready: Arc::new(AtomicBool::new(true)),
         };
 
         // First query — cache miss: file is downloaded from MinIO.
@@ -2268,6 +2299,7 @@ mod tests {
             job_timeout_secs: 60,
             job_semaphore: Arc::new(Semaphore::new(8)),
             per_client_queue_cap: 5,
+            consumer_ready: Arc::new(AtomicBool::new(true)),
         };
 
         let app = Router::new()
@@ -2422,6 +2454,7 @@ mod tests {
             job_timeout_secs: 60,
             job_semaphore: Arc::clone(&job_semaphore),
             per_client_queue_cap: 5,
+            consumer_ready: Arc::new(AtomicBool::new(true)),
         };
 
         let app = make_job_app(state);
@@ -2480,6 +2513,7 @@ mod tests {
             job_timeout_secs: 60,
             job_semaphore: Arc::new(Semaphore::new(8)),
             per_client_queue_cap: 5,
+            consumer_ready: Arc::new(AtomicBool::new(true)),
         };
 
         let app = make_job_app(state);
@@ -2532,6 +2566,7 @@ mod tests {
             job_timeout_secs: 60,
             job_semaphore: Arc::new(Semaphore::new(8)),
             per_client_queue_cap: 5,
+            consumer_ready: Arc::new(AtomicBool::new(true)),
         };
 
         let app = Router::new()
@@ -2612,6 +2647,7 @@ mod tests {
             job_timeout_secs: 60,
             job_semaphore: Arc::clone(&job_semaphore),
             per_client_queue_cap: 5,
+            consumer_ready: Arc::new(AtomicBool::new(true)),
         };
 
         let app = make_job_app(state);
@@ -2729,6 +2765,7 @@ mod tests {
                 m2,
                 pauses_clone,
                 Arc::new(Semaphore::new(4)),
+                Arc::new(AtomicBool::new(false)),
                 rx,
             )
             .await;
@@ -2745,7 +2782,7 @@ mod tests {
             "expected at least one backpressure pause"
         );
 
-        let state = AppState { manifest, minio: MinioConfig::default(), cold_semaphore: Arc::new(Semaphore::new(4)), cold_cache: Arc::new(Mutex::new(ColdCache::new(std::env::temp_dir().join("log-ingest-test-cache"), 10 * 1024 * 1024 * 1024).unwrap())), job_store: Arc::new(Mutex::new(HashMap::new())), jobs_dir: std::env::temp_dir().join("log-ingest-test-jobs"), job_timeout_secs: 300, job_semaphore: Arc::new(Semaphore::new(8)), per_client_queue_cap: 5 };
+        let state = AppState { manifest, minio: MinioConfig::default(), cold_semaphore: Arc::new(Semaphore::new(4)), cold_cache: Arc::new(Mutex::new(ColdCache::new(std::env::temp_dir().join("log-ingest-test-cache"), 10 * 1024 * 1024 * 1024).unwrap())), job_store: Arc::new(Mutex::new(HashMap::new())), jobs_dir: std::env::temp_dir().join("log-ingest-test-jobs"), job_timeout_secs: 300, job_semaphore: Arc::new(Semaphore::new(8)), per_client_queue_cap: 5, consumer_ready: Arc::new(AtomicBool::new(true)) };
         let rows = query_rows(
             state,
             QueryRequest {
@@ -2762,5 +2799,97 @@ mod tests {
             "expected {N} events after backpressure cycles, got {}",
             rows.len()
         );
+    }
+
+    #[tokio::test]
+    async fn metrics_report_events_and_queries() {
+        use axum::body::to_bytes;
+        use axum::http::Request;
+        use metrics_exporter_prometheus::PrometheusBuilder;
+        use std::sync::OnceLock;
+
+        static PROM: OnceLock<metrics_exporter_prometheus::PrometheusHandle> = OnceLock::new();
+        let prom_handle = PROM.get_or_init(|| {
+            PrometheusBuilder::new().install_recorder().unwrap()
+        });
+
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let mut manifest = Manifest::open(&tmp.path().join("manifest.db")).unwrap();
+
+        let event = event_schema::LogEvent {
+            service: "svc-metrics".into(),
+            timestamp: 1_700_000_000_000_000_000,
+            kafka_partition: 0,
+            kafka_offset: 1,
+            level: event_schema::Level::Info,
+            message: "metrics test".into(),
+            attributes: Default::default(),
+        };
+        flush_events(&[event], &data_dir, &mut manifest).unwrap();
+
+        let state = make_state(Manifest::open(&tmp.path().join("manifest.db")).unwrap());
+        // Re-open to get the flushed file registered; reuse the same db path.
+        let manifest2 = Arc::new(Mutex::new(
+            Manifest::open(&tmp.path().join("manifest.db")).unwrap(),
+        ));
+        let jobs_dir = tmp.path().join("jobs");
+        std::fs::create_dir_all(&jobs_dir).unwrap();
+        let state = AppState {
+            manifest: manifest2,
+            jobs_dir,
+            consumer_ready: Arc::new(AtomicBool::new(true)),
+            ..state
+        };
+
+        let h = prom_handle.clone();
+        let app = Router::new()
+            .route("/query", post(query_handler))
+            .route("/metrics", axum::routing::get(move || {
+                let h = h.clone();
+                async move { h.render() }
+            }))
+            .with_state(state);
+
+        // Run a query to populate query_duration_seconds.
+        let req = Request::builder()
+            .method("POST")
+            .uri("/query")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"sql":"SELECT * FROM logs WHERE service='svc-metrics'","time_from":0,"time_to":9223372036854775807}"#,
+            ))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let _ = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+
+        // Scrape /metrics.
+        let req = Request::builder()
+            .uri("/metrics")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let text = std::str::from_utf8(&body).unwrap().to_owned();
+
+        // events_ingested_total must be non-zero (incremented by flush_events above).
+        let events_val: f64 = text
+            .lines()
+            .find(|l| l.starts_with("events_ingested_total{") && !l.starts_with('#'))
+            .and_then(|l| l.split_whitespace().last())
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0.0);
+        assert!(events_val > 0.0, "events_ingested_total should be > 0, got {events_val}");
+
+        // query_duration_seconds_sum must be non-zero (incremented by the query above).
+        let qd_val: f64 = text
+            .lines()
+            .find(|l| l.starts_with("query_duration_seconds_sum") && !l.starts_with('#'))
+            .and_then(|l| l.split_whitespace().last())
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0.0);
+        assert!(qd_val > 0.0, "query_duration_seconds_sum should be > 0, got {qd_val}");
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -651,6 +651,20 @@ async fn main() {
         .install_recorder()
         .expect("failed to install Prometheus recorder");
 
+    metrics::describe_counter!("events_ingested_total", "Total log events written to Parquet.");
+    metrics::describe_histogram!("flush_duration_seconds", "Time to flush a partition batch to Parquet.");
+    metrics::describe_gauge!("buffer_occupancy_ratio", "Current fill ratio of each partition's batch buffer (0–1).");
+    metrics::describe_gauge!("kafka_consumer_lag", "Unconsumed messages between committed offset and high-watermark.");
+    metrics::describe_counter!("backpressure_pauses_total", "Times a Kafka partition was paused due to backpressure.");
+    metrics::describe_gauge!("files_active", "Number of active Parquet files by storage tier.");
+    metrics::describe_gauge!("files_compacting", "1 while a compaction run is in progress, 0 otherwise.");
+    metrics::describe_histogram!("query_duration_seconds", "End-to-end latency of streaming queries.");
+    metrics::describe_counter!("bytes_scanned_total", "Bytes of Parquet data scanned by queries.");
+    metrics::describe_gauge!("active_queries", "Number of queries currently streaming results.");
+    metrics::describe_counter!("rate_limit_rejected_total", "Job submissions rejected by the per-client queue cap.");
+    metrics::describe_counter!("cache_hits_total", "Cold-tier cache hits (file served from local disk).");
+    metrics::describe_counter!("cache_misses_total", "Cold-tier cache misses (file downloaded from MinIO).");
+
     let data_dir = PathBuf::from(
         std::env::var("DATA_DIR").unwrap_or_else(|_| "data".to_string()),
     );


### PR DESCRIPTION
## Summary

- **`GET /health`** — liveness probe, always `200 OK`
- **`GET /ready`** — readiness probe; `200` when Kafka consumer has subscribed, `503` otherwise (`consumer_ready: Arc<AtomicBool>` set by `run_consumer` after `subscribe()`)
- **`GET /metrics`** — Prometheus text format (endpoint was stubbed; now fully instrumented)
- **Grafana dashboard** auto-provisioned on `docker compose up` via `grafana/provisioning/dashboards/`

### Metrics instrumented

| Metric | Type | Labels |
|--------|------|--------|
| `events_ingested_total` | counter | `service`, `partition` |
| `flush_duration_seconds` | histogram | — |
| `buffer_occupancy_ratio` | gauge | `partition` |
| `kafka_consumer_lag` | gauge | `partition` |
| `backpressure_pauses_total` | counter | `partition` |
| `files_active` | gauge | `tier` |
| `files_compacting` | gauge | — |
| `query_duration_seconds` | histogram | — |
| `bytes_scanned_total` | counter | — |
| `active_queries` | gauge | — |
| `rate_limit_rejected_total` | counter | — |
| `cache_hits_total` / `cache_misses_total` | counters | — |

### Dashboard panels
Ingest rate · Consumer lag · Flush latency p50/p99 · Query duration p50/p99 · Active queries · Files by tier · Cold cache hit rate · Rate-limit rejections · Bytes scanned · Backpressure pauses · Buffer occupancy

## Test plan

- [x] `cargo test -p server` — 20 tests pass, including new `metrics_report_events_and_queries` (flush event → run query → scrape `/metrics` → assert `events_ingested_total > 0` and `query_duration_seconds_sum > 0`)
- [x] All 8 QA suites (`run_all.sh`) still green
- [x] `GET /health` returns `200` (existing stub replaced with proper handler)
- [x] `GET /ready` returns `503` before consumer subscribes, `200` after
- [x] Grafana dashboard JSON validates and loads automatically after `docker compose up`

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)