### PR TITLE
feat(#29): frontend async job UI

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -351,7 +351,7 @@ export default function Home() {
     setLoading(false);
   }, [job, stopPolling]);
 
-  const downloadCsv = useCallback(async (id: string) => {
+  const downloadCsv = useCallback(async (id?: string) => {
     const currentRows = rows;
     if (!currentRows?.length) return;
 
@@ -368,7 +368,7 @@ export default function Home() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `job-${id.slice(0, 8)}.csv`;
+    a.download = id ? `job-${id.slice(0, 8)}.csv` : `query-${Date.now()}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   }, [rows]);
@@ -653,8 +653,8 @@ export default function Home() {
               )}
 
               {/* Download CSV */}
-              {job?.state === 'complete' && !!rows?.length && (
-                <button onClick={() => downloadCsv(job.id)} className="px-4 py-1.5 rounded border border-green-700 hover:border-green-500 text-green-400 hover:text-green-300 text-sm font-medium transition-colors">
+              {!!rows?.length && !loading && (
+                <button onClick={() => downloadCsv(job?.id)} className="px-4 py-1.5 rounded border border-green-700 hover:border-green-500 text-green-400 hover:text-green-300 text-sm font-medium transition-colors">
                   Download CSV
                 </button>
               )}


### PR DESCRIPTION
Closes #29

## Summary
- **Async toggle**: purple "Async" button switches submission from inline streaming (`POST /query`) to background job (`POST /jobs`)
- **Submit → poll**: posts job, polls `GET /jobs/:id` every 1s via recursive `setTimeout` until terminal state
- **Progressive results**: pages through `GET /jobs/:id/results` (500 rows/page), updating the table incrementally
- **Cancel**: "Cancel Job" fires `DELETE /jobs/:id`, surfaces error banner on non-204 instead of silently succeeding
- **Download CSV**: appears after any completed query — inline or async — with appropriate filename (`query-<ts>.csv` or `job-<id>.csv`)
- **Jobs history**: persists last 20 jobs in `localStorage`; clicking any entry reloads results without re-running
- **Dev proxy**: `next.config.ts` forwards `/jobs`, `/query`, `/ingest`, `/metrics` etc. to `:8080` in dev mode; `output: 'export'` preserved for production

## Bug fixes included
- Job status banner, Cancel Job button, and row count bar no longer toggle on/off with the Async mode switch
- Server worker task now responds to cancellation while waiting for a semaphore permit (previously leaked tasks with `MAX_CONCURRENT_JOBS=0`)

## Acceptance criteria
- [x] Long-running queries can be submitted as async jobs from the UI
- [x] UI shows job ID and live state transitions (`queued` → `running` → `complete`)
- [x] Results load progressively into the table
- [x] Cancel button calls `DELETE /jobs/{id}` and updates UI state to `cancelled`
- [x] Download CSV available for both async and inline query results
- [x] Completed job results can be revisited from the Jobs history dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)